### PR TITLE
adding Errno::ETIMEDOUT rescue for pagseguro

### DIFF
--- a/lib/offsite_payments/integrations/pag_seguro.rb
+++ b/lib/offsite_payments/integrations/pag_seguro.rb
@@ -108,7 +108,7 @@ module OffsitePayments #:nodoc:
           check_for_errors(response, xml)
 
           extract_token(xml)
-        rescue Timeout::Error, Errno::ECONNRESET => e
+        rescue Timeout::Error, Errno::ECONNRESET, Errno::ETIMEDOUT => e
           raise ActionViewHelperError, "Erro ao conectar-se ao PagSeguro. Por favor, tente novamente."
         end
 

--- a/test/unit/integrations/pag_seguro/pag_seguro_helper_test.rb
+++ b/test/unit/integrations/pag_seguro/pag_seguro_helper_test.rb
@@ -156,4 +156,12 @@ class PagSeguroHelperTest < Test::Unit::TestCase
     @helper.customer :first_name => '  Cody  Yo ', :last_name => 'Fau  ser     ', :email => 'cody@example.com', phone: "71 98765432"
     assert_field 'senderName', 'Cody Yo Fau ser'
   end
+
+  def test_fetch_token_raise_view_helper_error_if_ETIMEDOUT_error
+    Net::HTTP.any_instance.expects(:request).raises(Errno::ETIMEDOUT, "Connection timed out")
+
+    assert_raise ActionViewHelperError do
+      @helper.fetch_token
+    end
+  end
 end


### PR DESCRIPTION
@bslobodin @odorcicd 
Just pushing the PR again from ActiveMerchant to OffsitePayments.
closes https://github.com/Shopify/offsite_payments/issues/41
