### PR TITLE
fixing addressComplement in PagSeguro

### DIFF
--- a/lib/offsite_payments/integrations/pag_seguro.rb
+++ b/lib/offsite_payments/integrations/pag_seguro.rb
@@ -64,7 +64,7 @@ module OffsitePayments #:nodoc:
 
         mapping :billing_address, :city     => 'shippingAddressCity',
                                   :address1 => 'shippingAddressStreet',
-                                  :address2 => 'shippingAddressNumber',
+                                  :address2 => 'shippingAddressComplement',
                                   :state    => 'shippingAddressState',
                                   :zip      => 'shippingAddressPostalCode',
                                   :country  => 'shippingAddressCountry'

--- a/test/unit/integrations/pag_seguro/pag_seguro_helper_test.rb
+++ b/test/unit/integrations/pag_seguro/pag_seguro_helper_test.rb
@@ -71,13 +71,14 @@ class PagSeguroHelperTest < Test::Unit::TestCase
 
   def test_address_mapping
     @helper.billing_address :address1 => '1 My Street',
-                            :address2 => '',
+                            :address2 => 'Ed. Por do Sol, Apt 1033',
                             :city => 'Leeds',
                             :state => 'SP',
                             :zip => 'LS2 7EE',
                             :country  => 'CA'
 
     assert_field 'shippingAddressStreet', '1 My Street'
+    assert_field 'shippingAddressComplement', 'Ed. Por do Sol, Apt 1033'
     assert_field 'shippingAddressCity', 'Leeds'
     assert_field 'shippingAddressState', 'SP'
     assert_field 'shippingAddressPostalCode', 'LS2 7EE'


### PR DESCRIPTION
@arthurnn @odorcicd @bslobodin 
cc @SamButler 

PagSeguro `shippingAddressNumber` only accepts numbers, so we should use the `shippingAddressComplement` for `address2` instead.
