### PR TITLE
Remove notify_url for 2Checkout

### DIFF
--- a/lib/offsite_payments/integrations/two_checkout.rb
+++ b/lib/offsite_payments/integrations/two_checkout.rb
@@ -82,9 +82,6 @@ module OffsitePayments #:nodoc:
         # Overrides Approved URL for return process redirects
         mapping :return_url, 'x_receipt_link_url'
 
-        # notifications are sent via static URLs in the Instant Notification Settings of 2Checkout admin
-        mapping :notify_url, 'notify_url'
-
         # Allow seller to indicate the step of the checkout page
         # Possible values: ‘review-cart’, ‘shipping-information’, ‘shipping-method’, ‘billing-information’ and ‘payment-method’
         mapping :purchase_step, 'purchase_step'

--- a/test/unit/integrations/two_checkout/two_checkout_helper_test.rb
+++ b/test/unit/integrations/two_checkout/two_checkout_helper_test.rb
@@ -21,13 +21,11 @@ class TwoCheckoutHelperTest < Test::Unit::TestCase
     @helper.currency 'ZAR'
     @helper.invoice '123'
     @helper.return_url 'https://return.url/'
-    @helper.notify_url 'https://notify.url/'
     @helper.cart_type 'shopify'
     @helper.purchase_step 'payment-method'
 
     assert_field 'currency_code', 'ZAR'
     assert_field 'cart_order_id', '123'
-    assert_field 'notify_url', 'https://notify.url/'
     assert_field 'x_receipt_link_url', 'https://return.url/'
     assert_field '2co_cart_type', 'shopify'
     assert_field 'purchase_step', 'payment-method'


### PR DESCRIPTION
@bizla @odorcicd /cc @Shopify/payments.

This is not a valid parameter from what I can tell, no need to supply it.

https://www.2checkout.com/documentation/checkout/parameters/
