### PR TITLE
adding string limits for billing address

### DIFF
--- a/lib/offsite_payments/integrations/pag_seguro.rb
+++ b/lib/offsite_payments/integrations/pag_seguro.rb
@@ -72,7 +72,6 @@ module OffsitePayments #:nodoc:
           add_field('shippingAddressComplement', params[:address2].slice(0, 40)) if params[:address2]
           add_field('shippingAddressState',      params[:state])
           add_field('shippingAddressPostalCode', params[:zip].delete("^0-9").slice(0, 8)) if params[:zip]
-          add_field('shippingAddressCountry',    "BRA")
         end
 
         def form_fields

--- a/test/unit/integrations/pag_seguro/pag_seguro_helper_test.rb
+++ b/test/unit/integrations/pag_seguro/pag_seguro_helper_test.rb
@@ -82,7 +82,6 @@ class PagSeguroHelperTest < Test::Unit::TestCase
     assert_field 'shippingAddressCity', 'Leeds'
     assert_field 'shippingAddressState', 'SP'
     assert_field 'shippingAddressPostalCode', '41825855'
-    assert_field 'shippingAddressCountry', 'BRA' #making sure we always use 'BRA'
   end
 
   def test_address_mapping_limits
@@ -103,7 +102,7 @@ class PagSeguroHelperTest < Test::Unit::TestCase
 
   def test_unknown_address_mapping
     @helper.shipping_address :farm => 'CA'
-    assert_equal 9, @helper.fields.size
+    assert_equal 8, @helper.fields.size
   end
 
   def test_unknown_mapping


### PR DESCRIPTION
@odorcicd @bslobodin 
https://pagseguro.uol.com.br/v2/guia-de-integracao/api-de-pagamentos.html

This adds a list of limits for the strings send to PagSeguro. If present, I just slice it. If the string is too big, PagSeguro explodes. ¬¬
