### PR TITLE
catching invalid xml parsing and raising with it's content

### DIFF
--- a/lib/offsite_payments/integrations/pag_seguro.rb
+++ b/lib/offsite_payments/integrations/pag_seguro.rb
@@ -243,6 +243,8 @@ module OffsitePayments #:nodoc:
         # Take the posted data and move the relevant data into a hash
         def parse_xml(post)
           @params = Hash.from_xml(post)
+        rescue => e
+          raise StandardError.new("#{e.class}: #{e.message} - Response: '#{post}'")
         end
 
         def parse_http_query(post)

--- a/test/unit/integrations/pag_seguro/pag_seguro_notification_test.rb
+++ b/test/unit/integrations/pag_seguro/pag_seguro_notification_test.rb
@@ -52,6 +52,14 @@ class PagSeguroNotificationTest < Test::Unit::TestCase
     assert_equal "Pending", pag_seguro.status
   end
 
+  def test_invalid_xml_response
+    Net::HTTP.expects(:get_response).with(@uri).returns(stub(body: "Not found"))
+
+    assert_raise(StandardError) do
+      PagSeguro::Notification.new(notification_data)
+    end
+  end
+
   private
   def notification_code
     "766B9C-AD4B044B04DA-77742F5FA653-E1AB24"


### PR DESCRIPTION
and my love for PagSeguro continues...
@odorcicd @bslobodin 

This will catch and raise the XML parse error with the content of the request (something we are not seeing in our logs). 

I'm catching `=> e` because we use a different XML parser in Shopify `REXML vs Nokogiri`. ActiveSupport makes `Hash.from_xml` to use Nokorigi. Maybe we should do the same but without adding `active_support`?
