### PR TITLE
Pagseguro invalid HTTP code

### DIFF
--- a/lib/offsite_payments/integrations/pag_seguro.rb
+++ b/lib/offsite_payments/integrations/pag_seguro.rb
@@ -237,14 +237,17 @@ module OffsitePayments #:nodoc:
           uri.query = URI.encode_www_form(params)
 
           response = Net::HTTP.get_response(uri)
+
+          if response.code.to_i > 400
+            raise StandardError.new("Response body: '#{response.body}' Response code: #{response.code}")
+          end
+
           response.body
         end
 
         # Take the posted data and move the relevant data into a hash
         def parse_xml(post)
           @params = Hash.from_xml(post)
-        rescue => e
-          raise StandardError.new("#{e.class}: #{e.message} - Response: '#{post}'")
         end
 
         def parse_http_query(post)

--- a/test/unit/integrations/pag_seguro/pag_seguro_module_test.rb
+++ b/test/unit/integrations/pag_seguro/pag_seguro_module_test.rb
@@ -4,7 +4,7 @@ class PagSeguroModuleTest < Test::Unit::TestCase
   include OffsitePayments::Integrations
 
   def test_notification_method
-    Net::HTTP.expects(:get_response).returns(stub(body: "<xml></xml>"))
+    Net::HTTP.expects(:get_response).returns(stub(code: "200", body: "<xml></xml>"))
     assert_instance_of PagSeguro::Notification, PagSeguro.notification('notificationCode=1234')
   end
 

--- a/test/unit/integrations/pag_seguro/pag_seguro_notification_test.rb
+++ b/test/unit/integrations/pag_seguro/pag_seguro_notification_test.rb
@@ -10,7 +10,7 @@ class PagSeguroNotificationTest < Test::Unit::TestCase
   end
 
   def test_accessors
-    Net::HTTP.expects(:get_response).with(@uri).returns(stub(body: http_raw_data))
+    Net::HTTP.expects(:get_response).with(@uri).returns(stub(code: "200", body: http_raw_data))
     pag_seguro = PagSeguro::Notification.new(notification_data)
 
     assert pag_seguro.complete?
@@ -25,19 +25,19 @@ class PagSeguroNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    Net::HTTP.expects(:get_response).with(@uri).returns(stub(body: http_raw_data))
+    Net::HTTP.expects(:get_response).with(@uri).returns(stub(code: "200", body: http_raw_data))
     pag_seguro = PagSeguro::Notification.new(notification_data)
     assert_equal Money.new(4912, 'BRL'), pag_seguro.amount
   end
 
   def test_respond_to_acknowledge
-    Net::HTTP.expects(:get_response).with(@uri).returns(stub(body: http_raw_data))
+    Net::HTTP.expects(:get_response).with(@uri).returns(stub(code: "200", body: http_raw_data))
     pag_seguro = PagSeguro::Notification.new(notification_data)
     assert pag_seguro.respond_to?(:acknowledge)
   end
 
   def test_pending_state_when_status_1
-    Net::HTTP.expects(:get_response).with(@uri).returns(stub(body: http_raw_data_status_only(1)))
+    Net::HTTP.expects(:get_response).with(@uri).returns(stub(code: "200", body: http_raw_data_status_only(1)))
     pag_seguro = PagSeguro::Notification.new(notification_data)
 
     refute pag_seguro.complete?
@@ -45,18 +45,32 @@ class PagSeguroNotificationTest < Test::Unit::TestCase
   end
 
   def test_pending_state_when_status_2
-    Net::HTTP.expects(:get_response).with(@uri).returns(stub(body: http_raw_data_status_only(2)))
+    Net::HTTP.expects(:get_response).with(@uri).returns(stub(code: "200", body: http_raw_data_status_only(2)))
     pag_seguro = PagSeguro::Notification.new(notification_data)
 
     refute pag_seguro.complete?
     assert_equal "Pending", pag_seguro.status
   end
 
-  def test_invalid_xml_response
-    Net::HTTP.expects(:get_response).with(@uri).returns(stub(body: "Not found"))
+  def test_404_response
+    Net::HTTP.expects(:get_response).with(@uri).returns(stub(code: "404", body: "Not found"))
 
-    assert_raise(StandardError) do
+    begin
       PagSeguro::Notification.new(notification_data)
+    rescue StandardError => e
+      assert_equal StandardError, e.class
+      assert_equal "Response body: 'Not found' Response code: 404", e.message
+    end
+  end
+
+  def test_401_response
+    Net::HTTP.expects(:get_response).with(@uri).returns(stub(code: "401", body: "Unauthorized"))
+
+    begin
+      PagSeguro::Notification.new(notification_data)
+    rescue StandardError => e
+      assert_equal StandardError, e.class
+      assert_equal "Response body: 'Unauthorized' Response code: 401", e.message
     end
   end
 


### PR DESCRIPTION
@odorcicd @bslobodin 

Instead of trying to parse the XML, I'm checking for the response code and raising the error with the content of the body and the http code.
