### PR TITLE
Add extra accessors for paypal notifications

### DIFF
--- a/lib/offsite_payments/integrations/paypal.rb
+++ b/lib/offsite_payments/integrations/paypal.rb
@@ -192,6 +192,56 @@ module OffsitePayments #:nodoc:
           status == "Completed"
         end
 
+        # Was the transaction reversal canceled?
+        def canceled_reversal?
+          status == "Canceled_Reversal"
+        end
+
+        # Was the transaction created?
+        def created?
+          status == "Created"
+        end
+
+        # Was the transaction denied?
+        def denied?
+          status == "Denied"
+        end
+
+        # Was the transaction expired?
+        def expired?
+          status == "Expired"
+        end
+
+        # Was the transaction failed?
+        def failed?
+          status == "Failed"
+        end
+
+        # Was the transaction pending?
+        def pending?
+          status == "Pending"
+        end
+
+        # Was the transaction refunded?
+        def refunded?
+          status == "Refunded"
+        end
+
+        # Was the transaction reversed?
+        def reversed?
+          status == "Reversed"
+        end
+
+        # Was the transaction processed?
+        def processed?
+          status == "Processed"
+        end
+
+        # Was the transaction voided?
+        def voided?
+          status == "Voided"
+        end
+
         # Is it a masspay notification?
         def masspay?
           type == "masspay"

--- a/lib/offsite_payments/integrations/paypal.rb
+++ b/lib/offsite_payments/integrations/paypal.rb
@@ -327,6 +327,24 @@ module OffsitePayments #:nodoc:
           params['business'] || params['receiver_email']
         end
 
+        # Status of a pending transaction. Returns nil if not pending.
+        # List of possible values when pending:
+        # <tt>address</tt>::
+        # <tt>authorization</tt>::
+        # <tt>echeck</tt>::
+        # <tt>intl</tt>::
+        # <tt>multi-currency</tt>::
+        # <tt>order</tt>::
+        # <tt>paymentreview</tt>::
+        # <tt>regulartory_review</tt>::
+        # <tt>unilateral</tt>::
+        # <tt>upgrade</tt>::
+        # <tt>verify</tt>::
+        # <tt>other</tt>::
+        def pending_reason
+          params['pending_reason']
+        end
+
         # Acknowledge the transaction to paypal. This method has to be called after a new
         # ipn arrives. Paypal will verify that all the information we received are correct and will return a
         # ok or a fail.

--- a/lib/offsite_payments/integrations/paypal.rb
+++ b/lib/offsite_payments/integrations/paypal.rb
@@ -345,6 +345,28 @@ module OffsitePayments #:nodoc:
           params['pending_reason']
         end
 
+        # This variable is set if payment_status is Reversed, Refunded,
+        # Canceled_Reversal, or Denied. Otherwise is nil.
+        # List of possible values when pending:
+        # <tt>adjustment_reversal</tt>::
+        # <tt>admin_fraud_reversal</tt>::
+        # <tt>admin_reversal</tt>::
+        # <tt>buyer-complaint</tt>::
+        # <tt>chargeback</tt>::
+        # <tt>chargeback_reimbursement</tt>::
+        # <tt>chargeback_settlement</tt>::
+        # <tt>guarantee</tt>::
+        # <tt>other</tt>::
+        # <tt>refund</tt>::
+        # <tt>regulatory_block</tt>::
+        # <tt>regulartory_reject</tt>::
+        # <tt>regulatory_review_exceeding_sla</tt>::
+        # <tt>unauthorized_claim</tt>::
+        # <tt>unauthorized_spoof</tt>::
+        def reason_code
+          params['reason_code']
+        end
+
         # Acknowledge the transaction to paypal. This method has to be called after a new
         # ipn arrives. Paypal will verify that all the information we received are correct and will return a
         # ok or a fail.

--- a/test/unit/integrations/paypal/paypal_notification_test.rb
+++ b/test/unit/integrations/paypal/paypal_notification_test.rb
@@ -21,6 +21,7 @@ class PaypalNotificationTest < Test::Unit::TestCase
     assert !@paypal.processed?
     assert !@paypal.voided?
     assert !@paypal.masspay?
+    assert @paypal.pending_reason.nil?
     assert_equal "Completed", @paypal.status
     assert_equal "6G996328CK404320L", @paypal.transaction_id
     assert_equal "web_accept", @paypal.type
@@ -29,6 +30,11 @@ class PaypalNotificationTest < Test::Unit::TestCase
     assert_equal "CAD", @paypal.currency
     assert_equal 'tobi@leetsoft.com' , @paypal.account
     assert @paypal.test?
+  end
+
+  def test_pending_reason
+    notification = Paypal::Notification.new(pending_transaction_http_raw_data)
+    assert_equal "paymentreview", notification.pending_reason
   end
 
   def test_mass_pay_accessors
@@ -140,5 +146,9 @@ class PaypalNotificationTest < Test::Unit::TestCase
 
   def mass_pay_http_raw_data
     "payer_id=LPV4F4HZHCE&payment_date=06%3A25%3A37+Oct+25%2C+2012+PDT&payment_gross_1=&payment_gross_2=&payment_gross_3=&payment_status=Completed&receiver_email_1=buyer_1348066306_per%40example.com&receiver_email_2=buyer_1351170859_per%40example.com&charset=windows-1252&receiver_email_3=buyer_1351170993_per%40example.com&mc_currency_1=GBP&masspay_txn_id_1=7XW35917TG8293137&mc_currency_2=GBP&masspay_txn_id_2=79512417EL9296629&mc_currency_3=GBP&masspay_txn_id_3=75X24749Y32677910&first_name=Test&unique_id_1=123&notify_version=3.7&unique_id_2=456&unique_id_3=789&payer_status=verified&verify_sign=AwtKW.5QSiJCrI10IE.2gmVei1MEAwsHLftLIB9pXgu82MLXoCS1yeE-&payer_email=massuk_1351170591_biz%40example.com&payer_business_name=Tests%27s+Test+Store&last_name=Test&status_1=Completed&status_2=Completed&status_3=Completed&txn_type=masspay&mc_gross_1=10.00&mc_gross_2=24.50&mc_gross_3=20.00&payment_fee_1=&residence_country=GB&test_ipn=1&payment_fee_2=&payment_fee_3=&mc_fee_1=0.20&mc_fee_2=0.49&mc_fee_3=0.40&ipn_track_id=89f7ff244947f"
+  end
+
+  def pending_transaction_http_raw_data
+    "mc_gross=500.00&address_status=confirmed&payer_id=EVMXCLDZJV77Q&tax=0.00&address_street=164+Waverley+Street&payment_date=15%3A23%3A54+Apr+15%2C+2005+PDT&payment_status=Pending&pending_reason=paymentreview&address_zip=K2P0V6&first_name=Tobias&mc_fee=15.05&address_country_code=CA&address_name=Tobias+Luetke&notify_version=1.7&custom=&payer_status=unverified&business=tobi%40leetsoft.com&address_country=Canada&address_city=Ottawa&quantity=1&payer_email=tobi%40snowdevil.ca&verify_sign=AEt48rmhLYtkZ9VzOGAtwL7rTGxUAoLNsuf7UewmX7UGvcyC3wfUmzJP&txn_id=6G996328CK404320L&payment_type=instant&last_name=Luetke&address_state=Ontario&receiver_email=tobi%40leetsoft.com&payment_fee=&receiver_id=UQ8PDYXJZQD9Y&txn_type=web_accept&item_name=Store+Purchase&mc_currency=CAD&item_number=&test_ipn=1&payment_gross=&shipping=0.00"
   end
 end

--- a/test/unit/integrations/paypal/paypal_notification_test.rb
+++ b/test/unit/integrations/paypal/paypal_notification_test.rb
@@ -10,6 +10,16 @@ class PaypalNotificationTest < Test::Unit::TestCase
 
   def test_accessors
     assert @paypal.complete?
+    assert !@paypal.pending?
+    assert !@paypal.canceled_reversal?
+    assert !@paypal.created?
+    assert !@paypal.denied?
+    assert !@paypal.expired?
+    assert !@paypal.failed?
+    assert !@paypal.refunded?
+    assert !@paypal.reversed?
+    assert !@paypal.processed?
+    assert !@paypal.voided?
     assert !@paypal.masspay?
     assert_equal "Completed", @paypal.status
     assert_equal "6G996328CK404320L", @paypal.transaction_id

--- a/test/unit/integrations/paypal/paypal_notification_test.rb
+++ b/test/unit/integrations/paypal/paypal_notification_test.rb
@@ -22,6 +22,7 @@ class PaypalNotificationTest < Test::Unit::TestCase
     assert !@paypal.voided?
     assert !@paypal.masspay?
     assert @paypal.pending_reason.nil?
+    assert @paypal.reason_code.nil?
     assert_equal "Completed", @paypal.status
     assert_equal "6G996328CK404320L", @paypal.transaction_id
     assert_equal "web_accept", @paypal.type
@@ -35,6 +36,11 @@ class PaypalNotificationTest < Test::Unit::TestCase
   def test_pending_reason
     notification = Paypal::Notification.new(pending_transaction_http_raw_data)
     assert_equal "paymentreview", notification.pending_reason
+  end
+
+  def test_reason_code
+    notification = Paypal::Notification.new(denied_transaction_http_raw_data)
+    assert_equal "other", notification.reason_code
   end
 
   def test_mass_pay_accessors
@@ -150,5 +156,9 @@ class PaypalNotificationTest < Test::Unit::TestCase
 
   def pending_transaction_http_raw_data
     "mc_gross=500.00&address_status=confirmed&payer_id=EVMXCLDZJV77Q&tax=0.00&address_street=164+Waverley+Street&payment_date=15%3A23%3A54+Apr+15%2C+2005+PDT&payment_status=Pending&pending_reason=paymentreview&address_zip=K2P0V6&first_name=Tobias&mc_fee=15.05&address_country_code=CA&address_name=Tobias+Luetke&notify_version=1.7&custom=&payer_status=unverified&business=tobi%40leetsoft.com&address_country=Canada&address_city=Ottawa&quantity=1&payer_email=tobi%40snowdevil.ca&verify_sign=AEt48rmhLYtkZ9VzOGAtwL7rTGxUAoLNsuf7UewmX7UGvcyC3wfUmzJP&txn_id=6G996328CK404320L&payment_type=instant&last_name=Luetke&address_state=Ontario&receiver_email=tobi%40leetsoft.com&payment_fee=&receiver_id=UQ8PDYXJZQD9Y&txn_type=web_accept&item_name=Store+Purchase&mc_currency=CAD&item_number=&test_ipn=1&payment_gross=&shipping=0.00"
+  end
+
+  def denied_transaction_http_raw_data
+    "mc_gross=500.00&address_status=confirmed&payer_id=EVMXCLDZJV77Q&tax=0.00&address_street=164+Waverley+Street&payment_date=15%3A23%3A54+Apr+15%2C+2005+PDT&payment_status=Denied&reason_code=other&address_zip=K2P0V6&first_name=Tobias&mc_fee=15.05&address_country_code=CA&address_name=Tobias+Luetke&notify_version=1.7&custom=&payer_status=unverified&business=tobi%40leetsoft.com&address_country=Canada&address_city=Ottawa&quantity=1&payer_email=tobi%40snowdevil.ca&verify_sign=AEt48rmhLYtkZ9VzOGAtwL7rTGxUAoLNsuf7UewmX7UGvcyC3wfUmzJP&txn_id=6G996328CK404320L&payment_type=instant&last_name=Luetke&address_state=Ontario&receiver_email=tobi%40leetsoft.com&payment_fee=&receiver_id=UQ8PDYXJZQD9Y&txn_type=web_accept&item_name=Store+Purchase&mc_currency=CAD&item_number=&test_ipn=1&payment_gross=&shipping=0.00"
   end
 end


### PR DESCRIPTION
This 3-commit long pull request includes:
- helper methods to test all status (like pending? or denied?)
- a helper method to access pending_reason
- a helper mehtod to access reason_code

All information can be found on [the same paypal doc page](https://developer.paypal.com/docs/classic/ipn/integration-guide/IPNandPDTVariables/).
You can see all status, all pending_reasons and reason_codes there.
