### PR TITLE
iPay88 acknowledge should only requery when the status is success

### DIFF
--- a/test/unit/integrations/ipay88/ipay88_notification_test.rb
+++ b/test/unit/integrations/ipay88/ipay88_notification_test.rb
@@ -55,10 +55,10 @@ class Ipay88NotificationTest < Test::Unit::TestCase
     assert !@ipay88.acknowledge
   end
 
-  def test_unsuccessful_acknowledge_due_to_payment_failed
+  def test_successful_acknowledge_on_cancellation
     params = parameterize(payload)
-    ipay = build_notification(http_raw_data(:payment_failed))
-    assert !ipay.acknowledge
+    ipay = build_notification(http_raw_data(:payment_cancelled))
+    assert ipay.acknowledge
   end
 
   def test_unsuccessful_acknowledge_due_to_missing_amount
@@ -84,7 +84,7 @@ class Ipay88NotificationTest < Test::Unit::TestCase
       parameterize(base.merge("Signature" => "bPlMszCBwxlfGX9ZkgmSfT+OeLQ="))
     when :invalid_sig
       parameterize(base.merge("Signature" => "hacked"))
-    when :payment_failed
+    when :payment_cancelled
       parameterize(base.merge("Status" => 0, "Signature" => "p8nXYcl/wytpNMzsf31O/iu/2EU="))
     when :missing_amount
       parameterize(base.except("Amount"))


### PR DESCRIPTION
@bslobodin @bizla 

When iPay88 returns from an error state (such as cancellation), acknowledge returns false. They still pass us a signature, so we can still acknowledge. This fixes that by only calling `requery` when the status is success.
