### PR TITLE
Avoid duplicate acknowledge for Coinbase

### DIFF
--- a/lib/offsite_payments/integrations/coinbase.rb
+++ b/lib/offsite_payments/integrations/coinbase.rb
@@ -133,10 +133,6 @@ module OffsitePayments #:nodoc:
 
           parsed_hash
         end
-
-        def success?
-          @notification.acknowledge
-        end
       end
 
       protected

--- a/test/unit/integrations/coinbase/coinbase_return_test.rb
+++ b/test/unit/integrations/coinbase/coinbase_return_test.rb
@@ -11,6 +11,7 @@ class CoinbaseReturnTest < Test::Unit::TestCase
     Net::HTTP.any_instance.expects(:request).returns(stub(:body => valid_http_raw_data))
     coinbase_return = Coinbase::Return.new(valid_query_string, @options)
 
+    assert coinbase_return.notification.acknowledge
     assert coinbase_return.success?
   end
 
@@ -18,7 +19,8 @@ class CoinbaseReturnTest < Test::Unit::TestCase
     Net::HTTP.any_instance.expects(:request).returns(stub(:body => valid_http_raw_data))
     coinbase_return = Coinbase::Return.new(invalid_query_string, @options)
 
-    assert !coinbase_return.success?
+    assert !coinbase_return.notification.acknowledge
+    assert coinbase_return.success?
   end
 
   private


### PR DESCRIPTION
@justinplouffe, @odorcicd rightly pointed out that `success?` would actually end up doing a second `acknowledge` for no good reason. It's probably best to just remove it altogether.
