### PR TITLE
Improve Coinbase error handling

### DIFF
--- a/lib/offsite_payments/integrations/coinbase.rb
+++ b/lib/offsite_payments/integrations/coinbase.rb
@@ -52,10 +52,11 @@ module OffsitePayments #:nodoc:
           data = Coinbase.do_request(uri, @account, @options[:credential2], request_body)
           json = JSON.parse(data)
 
-          raise ActionViewHelperError, "Response invalid %s" % data if json.nil?
-          raise ActionViewHelperError, "JSON error %s" % JSON.pretty_generate(json) unless json['success']
+          raise ActionViewHelperError, "Error occured while contacting gateway : #{json['error']}" if json['error']
 
           {'id' => json['button']['code']}
+        rescue JSON::ParserError
+          raise ActionViewHelperError, 'Invalid response from gateway. Please try again.'
         end
       end
 

--- a/test/unit/integrations/coinbase/coinbase_helper_test.rb
+++ b/test/unit/integrations/coinbase/coinbase_helper_test.rb
@@ -12,4 +12,20 @@ class CoinbaseHelperTest < Test::Unit::TestCase
 
     assert_equal 'test123', @helper.form_fields['id']
   end
+
+  def test_raise_error_on_invalid_json
+    Net::HTTP.any_instance.expects(:request).returns(stub(:body => 'totally not json'))
+
+    assert_raise ActionViewHelperError do
+      @helper.form_fields
+    end
+  end
+
+  def test_raise_error_on_error_response
+    Net::HTTP.any_instance.expects(:request).returns(stub(:body => '{"error":"something bad happened"}'))
+
+    assert_raise ActionViewHelperError do
+      @helper.form_fields
+    end
+  end
 end


### PR DESCRIPTION
@bslobodin /cc @Shopify/payments Simply raise ActionViewHelperErrors instead. Should we change the error messages to something else?
