### PR TITLE
PagSeguro invalid acknowledge notification

### DIFF
--- a/test/unit/integrations/pag_seguro/pag_seguro_module_test.rb
+++ b/test/unit/integrations/pag_seguro/pag_seguro_module_test.rb
@@ -4,7 +4,7 @@ class PagSeguroModuleTest < Test::Unit::TestCase
   include OffsitePayments::Integrations
 
   def test_notification_method
-    Net::HTTP.expects(:get_response).returns(stub(body: "<xml></xml>"))
+    Net::HTTP.expects(:get_response).returns(stub(code: "200", body: "<xml></xml>"))
     assert_instance_of PagSeguro::Notification, PagSeguro.notification('notificationCode=1234')
   end
 

--- a/test/unit/integrations/pag_seguro/pag_seguro_notification_test.rb
+++ b/test/unit/integrations/pag_seguro/pag_seguro_notification_test.rb
@@ -10,7 +10,7 @@ class PagSeguroNotificationTest < Test::Unit::TestCase
   end
 
   def test_accessors
-    Net::HTTP.expects(:get_response).with(@uri).returns(stub(body: http_raw_data))
+    Net::HTTP.expects(:get_response).with(@uri).returns(stub(code: "200", body: http_raw_data))
     pag_seguro = PagSeguro::Notification.new(notification_data)
 
     assert pag_seguro.complete?
@@ -25,19 +25,19 @@ class PagSeguroNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    Net::HTTP.expects(:get_response).with(@uri).returns(stub(body: http_raw_data))
+    Net::HTTP.expects(:get_response).with(@uri).returns(stub(code: "200", body: http_raw_data))
     pag_seguro = PagSeguro::Notification.new(notification_data)
     assert_equal Money.new(4912, 'BRL'), pag_seguro.amount
   end
 
   def test_respond_to_acknowledge
-    Net::HTTP.expects(:get_response).with(@uri).returns(stub(body: http_raw_data))
+    Net::HTTP.expects(:get_response).with(@uri).returns(stub(code: "200", body: http_raw_data))
     pag_seguro = PagSeguro::Notification.new(notification_data)
     assert pag_seguro.respond_to?(:acknowledge)
   end
 
   def test_pending_state_when_status_1
-    Net::HTTP.expects(:get_response).with(@uri).returns(stub(body: http_raw_data_status_only(1)))
+    Net::HTTP.expects(:get_response).with(@uri).returns(stub(code: "200", body: http_raw_data_status_only(1)))
     pag_seguro = PagSeguro::Notification.new(notification_data)
 
     refute pag_seguro.complete?
@@ -45,11 +45,25 @@ class PagSeguroNotificationTest < Test::Unit::TestCase
   end
 
   def test_pending_state_when_status_2
-    Net::HTTP.expects(:get_response).with(@uri).returns(stub(body: http_raw_data_status_only(2)))
+    Net::HTTP.expects(:get_response).with(@uri).returns(stub(code: "200", body: http_raw_data_status_only(2)))
     pag_seguro = PagSeguro::Notification.new(notification_data)
 
     refute pag_seguro.complete?
     assert_equal "Pending", pag_seguro.status
+  end
+
+  def test_404_response
+    Net::HTTP.expects(:get_response).with(@uri).returns(stub(code: "404", body: "Not found"))
+
+    pag_seguro = PagSeguro::Notification.new(notification_data)
+    refute pag_seguro.acknowledge
+  end
+
+  def test_401_response
+    Net::HTTP.expects(:get_response).with(@uri).returns(stub(code: "401", body: "Unauthorized"))
+
+    pag_seguro = PagSeguro::Notification.new(notification_data)
+    refute pag_seguro.acknowledge
   end
 
   private


### PR DESCRIPTION
@odorcicd who else to ping?

**TLDR**; If the shop's token is no longer valid and PagSeguro sends us a ping, we should ignore it. 

When PagSeguro sends us a notification (a ping), they just send us a code. We need to do a request back to them to get info about the ping (we need to use the Shop's token for that). If the token is no longer valid, this request fails with HTTP response code `401`.

You can try with:

`curl -I https://ws.pagseguro.uol.com.br/v2/transactions/notifications/766B9C-AD4B044B04DA-77742F5FA653-E1AB24\?email\=suporte@lojamodelo.com.br\&token\=95112EE828D94278BD394E91C4388F20`

It returns a text, no XML, plus the status code.
## Solution

Store a acknowledge status if the request is no `200` and make the acknowledge method return false. It will make Shopify ignore the request.
