### PR TITLE
Update webmoney.rb

### DIFF
--- a/lib/offsite_payments/integrations/webmoney.rb
+++ b/lib/offsite_payments/integrations/webmoney.rb
@@ -38,7 +38,7 @@ module OffsitePayments #:nodoc:
         end
 
         def generate_signature
-          Digest::MD5.hexdigest(generate_signature_string).upcase
+          Digest::SHA256.hexdigest(generate_signature_string).upcase
         end
       end
 


### PR DESCRIPTION
Since webmoney has declined support of MD5 digest method, it’s better
to set SHA256 by default here.
