### PR TITLE
nil guard credentials in options hash

### DIFF
--- a/lib/offsite_payments/integrations/coinbase.rb
+++ b/lib/offsite_payments/integrations/coinbase.rb
@@ -28,6 +28,8 @@ module OffsitePayments #:nodoc:
           @order = order_id
           @account = account
           @options = options
+          @options[:credential1] ||= ''
+          @options[:credential2] ||= ''
         end
 
         mapping :notify_url, 'notify_url'


### PR DESCRIPTION
Coinbase API credentials are sent eagerly to `self.do_request`. If the API secret or API key is unspecified, the integration barfs. This simply initializes the credential strings to `''` so that the Coinbase API can return a complaint rather than the Ruby interpreter trying to convert `nil` to a String.  

@j-mutter @edward /cc @Shopify/payments 
