### PR TITLE
update coinbase API URIs

### DIFF
--- a/lib/offsite_payments/integrations/coinbase.rb
+++ b/lib/offsite_payments/integrations/coinbase.rb
@@ -2,13 +2,13 @@ module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Coinbase
       mattr_accessor :service_url
-      self.service_url = 'https://coinbase.com/checkouts/redirect'
+      self.service_url = 'https://www.coinbase.com/checkouts/redirect'
 
       mattr_accessor :buttoncreate_url
-      self.buttoncreate_url = 'https://coinbase.com/api/v1/buttons'
+      self.buttoncreate_url = 'https://api.coinbase.com/v1/buttons'
 
       mattr_accessor :notification_confirmation_url
-      self.notification_confirmation_url = 'https://coinbase.com/api/v1/orders/%s'
+      self.notification_confirmation_url = 'https://api.coinbase.com/v1/orders/%s'
 
       # options should be { credential1: "your API key", credential2: "your API secret" }
       def self.notification(post, options = {})


### PR DESCRIPTION
Checkout redirection was apparently broken on account of losing context on a **coinbase.com** -> **www.coinbase.com** 302. 

Also, the API URIs used have been deprecated, so I update them here too. 

This should restore checkout functionality. 

@j-mutter @edward /cc @Shopify/payments 
