### PR TITLE
Moving referrer_id to crypt field instead of the form field

### DIFF
--- a/lib/offsite_payments/integrations/sage_pay_form.rb
+++ b/lib/offsite_payments/integrations/sage_pay_form.rb
@@ -131,6 +131,8 @@ module OffsitePayments #:nodoc:
           fields['BillingPostCode'] ||= "0000"
           fields['DeliveryPostCode'] ||= "0000"
 
+          fields['ReferrerID'] = referrer_id if referrer_id
+
           crypt_skip = ['Vendor', 'EncryptKey', 'SendEmail']
           crypt_skip << 'BillingState'  unless fields['BillingCountry']  == 'US'
           crypt_skip << 'DeliveryState' unless fields['DeliveryCountry'] == 'US'
@@ -138,14 +140,12 @@ module OffsitePayments #:nodoc:
           key = fields['EncryptKey']
           @crypt ||= create_crypt_field(fields.except(*crypt_skip), key)
 
-          result = {
+          {
             'VPSProtocol' => '3.00',
             'TxType' => 'PAYMENT',
             'Vendor' => @fields['Vendor'],
             'Crypt'  => @crypt
           }
-          result['ReferrerID'] = referrer_id if referrer_id
-          result
         end
 
         private


### PR DESCRIPTION
In the previous update to [add the referrer_id](https://github.com/Shopify/active_merchant/commit/82a164c4bce7a360b7d6c75038d46c99137d3db9) it was added as a form field instead of in the crypt field where it should live. 

Added into the correct place and added some tests.

@girasquid @bizla /cc @Shopify/payments 
