### PR TITLE
Handle floating point errors in PayU Paisa notifications

### DIFF
--- a/lib/offsite_payments/integrations/payu_in.rb
+++ b/lib/offsite_payments/integrations/payu_in.rb
@@ -163,7 +163,7 @@ module OffsitePayments #:nodoc:
 
         # original amount send by merchant
         def gross
-          params['amount']
+          parse_and_round_gross_amount(params['amount'])
         end
 
         # This is discount given to user - based on promotion set by merchants.
@@ -232,6 +232,12 @@ module OffsitePayments #:nodoc:
             return false
           end
           true
+        end
+
+        private
+        def parse_and_round_gross_amount(amount)
+          rounded_amount = (amount.to_f * 100.0).round
+          sprintf("%.2f", rounded_amount / 100.00)
         end
       end
 

--- a/test/unit/integrations/payu_in_paisa/payu_in_paisa_notification_test.rb
+++ b/test/unit/integrations/payu_in_paisa/payu_in_paisa_notification_test.rb
@@ -38,6 +38,12 @@ class PayuInPaisaNotificationTest < Test::Unit::TestCase
     assert @payu.acknowledge
   end
 
+  def test_handles_floating_point_problems_in_amount
+    bad_data = http_raw_data.gsub('amount=10.00', 'amount=2337.2960000000003')
+    notification = PayuInPaisa::Notification.new(bad_data)
+    assert_equal '2337.30', notification.gross
+  end
+
   def test_item_id_gives_the_original_item_id
     assert 'original_item_id', @payu.item_id
   end

--- a/test/unit/integrations/payu_in_paisa/payu_in_paisa_return_test.rb
+++ b/test/unit/integrations/payu_in_paisa/payu_in_paisa_return_test.rb
@@ -32,7 +32,7 @@ class PayuInPaisaReturnTest < Test::Unit::TestCase
     assert notification.complete?
     assert_equal 'Completed', notification.status
     assert notification.invoice_ok?('4ba4afe87f7e73468f2a')
-    assert notification.amount_ok?(BigDecimal.new('10.00'),BigDecimal.new('0.00'))
+    assert notification.amount_ok?(BigDecimal.new('10.00'), BigDecimal.new('0.00'))
     assert_equal "success", notification.transaction_status
     assert_equal '403993715508030204', @payu.notification.transaction_id
     assert_equal 'CC', @payu.notification.type


### PR DESCRIPTION
@j-mutter @edward /cc @Shopify/payments @kristianpd 

PayU Paisa sometimes sends notifications that look like they have floating point errors in them - this change makes it so that `PayuInPaisa::Notification` handles that properly.
