### PR TITLE
Handle PayU notifications missing trailing 0 on two digit amounts

### DIFF
--- a/lib/offsite_payments/integrations/payu_in.rb
+++ b/lib/offsite_payments/integrations/payu_in.rb
@@ -162,6 +162,10 @@ module OffsitePayments #:nodoc:
         end
 
         # original amount send by merchant
+        def original_gross
+          params['amount']
+        end
+
         def gross
           parse_and_round_gross_amount(params['amount'])
         end
@@ -225,7 +229,7 @@ module OffsitePayments #:nodoc:
         end
 
         def checksum_ok?
-          checksum_fields = [transaction_status, *user_defined.reverse, customer_email, customer_first_name, product_info, gross, invoice]
+          checksum_fields = [transaction_status, *user_defined.reverse, customer_email, customer_first_name, product_info, original_gross, invoice]
 
           unless Digest::SHA512.hexdigest([@secret_key, *checksum_fields, @merchant_id].join("|")) == checksum
             @message = 'Return checksum not matching the data provided'

--- a/test/unit/integrations/payu_in_paisa/payu_in_paisa_notification_test.rb
+++ b/test/unit/integrations/payu_in_paisa/payu_in_paisa_notification_test.rb
@@ -44,6 +44,16 @@ class PayuInPaisaNotificationTest < Test::Unit::TestCase
     assert_equal '2337.30', notification.gross
   end
 
+  def test_checksum_uses_original_amount_even_if_it_has_problems
+    bad_data = http_raw_data.gsub('amount=10.00', 'amount=2337.2960000000003')
+    bad_data = bad_data.gsub("hash=#{checksum}", "hash=#{checksum('2337.2960000000003')}")
+    notification = PayuInPaisa::Notification.new(bad_data, :credential1 => 'merchant_id', :credential2 => 'secret')
+    assert_equal '2337.30', notification.gross
+    assert_equal '2337.2960000000003', notification.original_gross
+
+    assert_equal checksum("2337.2960000000003"), notification.checksum
+  end
+
   def test_item_id_gives_the_original_item_id
     assert 'original_item_id', @payu.item_id
   end
@@ -53,7 +63,7 @@ class PayuInPaisaNotificationTest < Test::Unit::TestCase
    "mihpayid=403993715508030204&mode=CC&status=success&unmappedstatus=captured&key=merchant_id&txnid=4ba4afe87f7e73468f2a&amount=10.00&discount=0.00&addedon=2013-05-10 18 32 30&productinfo=Product Info&firstname=Payu-Admin&lastname=&address1=&address2=&city=&state=&country=&zipcode=&email=test@example.com&phone=1234567890&udf1=&udf2=original_item_id&udf3=&udf4=&udf5=&udf6=&udf7=&udf8=&udf9=&udf10=&hash=#{checksum}&field1=313069903923&field2=999999&field3=59117331831301&field4=-1&field5=&field6=&field7=&field8=&PG_TYPE=HDFC&bank_ref_num=59117331831301&bankcode=CC&error=E000&cardnum=512345XXXXXX2346&cardhash=766f0227cc4b4c5f773a04cb31d8d1c5be071dd8d08fe365ecf5e2e5c947546d"
   end
 
-  def checksum
-    Digest::SHA512.hexdigest("secret|success|||||||||original_item_id||test@example.com|Payu-Admin|Product Info|10.00|4ba4afe87f7e73468f2a|merchant_id")
+  def checksum(amount="10.00")
+    Digest::SHA512.hexdigest("secret|success|||||||||original_item_id||test@example.com|Payu-Admin|Product Info|#{amount}|4ba4afe87f7e73468f2a|merchant_id")
   end
 end


### PR DESCRIPTION
@aprofeit @j-mutter /cc @Shopify/payments 

The fix for PayU's floating point problems caused problems because it also changed the format of `63.0` in notifications to be `63.00` - which made checksums break. This change goes back to using their original value for notification checksums, but leaves `gross` as the reformatted value.
