### PR TITLE
Handle floating point errors and trailing digits being removed by Pay U when checking returns

### DIFF
--- a/lib/offsite_payments/integrations/payu_in.rb
+++ b/lib/offsite_payments/integrations/payu_in.rb
@@ -116,7 +116,7 @@ module OffsitePayments #:nodoc:
 
         # Order amount should be equal to gross - discount
         def amount_ok?( order_amount, order_discount = BigDecimal.new( '0.0' ) )
-          BigDecimal.new( gross ) == order_amount && BigDecimal.new( discount.to_s ) == order_discount
+          BigDecimal.new( original_gross ) == order_amount && BigDecimal.new( discount.to_s ) == order_discount
         end
 
         # Status of transaction return from the PayU. List of possible values:

--- a/test/unit/integrations/payu_in_paisa/payu_in_paisa_return_test.rb
+++ b/test/unit/integrations/payu_in_paisa/payu_in_paisa_return_test.rb
@@ -16,6 +16,20 @@ class PayuInPaisaReturnTest < Test::Unit::TestCase
     assert_equal 'Completed', @payu.status('4ba4afe87f7e73468f2a','10.00')
   end
 
+  def test_success_with_floating_point_error
+    bad_data = http_raw_data_success.gsub('amount=10.00', 'amount=2337.2960000000003')
+    payu_return = PayuInPaisa::Return.new(bad_data, credential1: 'merchant_id', credential2: 'secret')
+
+    assert payu_return.success?
+  end
+
+  def test_success_with_stripped_trailing_digit
+    bad_data = http_raw_data_success.gsub('amount=10.00', 'amount=10.0')
+    payu_return = PayuInPaisa::Return.new(bad_data, credential1: 'merchant_id', credential2: 'secret')
+
+    assert payu_return.success?
+  end
+
   def test_failure_is_successful
     setup_failed_return
     assert_equal 'Failed', @payu.status('8ae1034d1abf47fde1cf', '10.00')


### PR DESCRIPTION
@edward @christianblais @j-mutter /cc @Shopify/payments 

`OffsitePayments::Return` also checks the amount that's coming back when it's confirming whether something is Ok or not - I missed updating this code last week to use the original gross amount that Pay U sends in.
