### PR TITLE
Fix load error if active_support/core_ext was not loaded before.

### DIFF
--- a/lib/offsite_payments.rb
+++ b/lib/offsite_payments.rb
@@ -5,6 +5,7 @@ require "socket"
 
 require 'active_support/core_ext/class/delegating_attributes'
 
+require 'active_utils'
 require 'active_utils/common/network_connection_retries'
 require 'active_utils/common/connection'
 require 'active_utils/common/requires_parameters'


### PR DESCRIPTION
ActiveUtils requires some ActiveSupport core extensions in its main file, namely class_attribute. Your library requires specific files of ActiveUtils directly. This way you get an error:

```
active_utils-2.2.3/lib/active_utils/common/post_data.rb:5:in `<class:PostData>': undefined method `class_attribute' for ActiveMerchant::PostData:Class (NoMethodError)
```

You can reproduce the error by loading just "offsite_payments" in a clean environment. This error does not occur in your tests because you explicitly require "action_controller" & "action_view" which in turn load these active_support core extensions.

You should also consider removing the explicit require of all ActiveUtils files since they are already set up as autoload in "active_utils" file, unless you have a reason to avoid autoload.
