### PR TITLE
Adds razorpay integration

### DIFF
--- a/lib/offsite_payments/integrations/razorpay.rb
+++ b/lib/offsite_payments/integrations/razorpay.rb
@@ -1,0 +1,139 @@
+module OffsitePayments #:nodoc:
+  module Integrations #:nodoc:
+    module Razorpay
+
+      mattr_accessor :service_url
+      self.service_url = 'https://checkout.razorpay.com/'
+
+      # options should be { credential1: "your key-id", credential2: "your key-secret" }
+      def self.notification(post, options = {})
+        Notification.new(post, options = {})
+      end
+
+      def self.sign(fields, key_secret)
+        fields.slice!(*['razorpay_payment_id', 'amount', 'currency', 'merchant_order_id'])
+        OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA1.new, key_secret, Hash[fields.sort].values.join('|'))
+      end
+
+      class Helper < OffsitePayments::Helper
+
+        mapping :account,          'key'
+        mapping :currency,         'currency'
+        mapping :order,            'merchant_order_id'
+        mapping :amount,           'amount'
+        mapping :country,          'notes[shop_country]'
+        mapping :account_name,     'name'
+        mapping :description,      'description'
+        mapping :invoice,          'notes[invoice]'
+
+        mapping :customer, :name       => 'prefill[name]',
+                           :email      => 'prefill[email]',
+                           :phone      => 'prefill[contact]'
+
+        mapping :shipping_address, :first_name => 'notes[shipping_first_name]',
+                                   :last_name =>  'notes[shipping_last_name]',
+                                   :city =>       'notes[shipping_city]',
+                                   :company =>    'notes[shipping_company]',
+                                   :address1 =>   'notes[shipping_address1]',
+                                   :address2 =>   'notes[shipping_address2]',
+                                   :state =>      'notes[shipping_state]',
+                                   :zip =>        'notes[shipping_zip]',
+                                   :country =>    'notes[shipping_country]',
+                                   :phone =>      'notes[shipping_phone]'
+
+        mapping        :return_url, 'url[callback]'
+        mapping :cancel_return_url, 'url[cancel]'
+
+        def initialize(order, account, options = {})
+          @key_secret = options[:credential2]
+          super
+        end
+
+        def amount=(amount)
+          # razorpay accepts amounts in paisa (ruppes*100)
+          add_field(mappings[:amount], (amount*100).round)
+        end
+
+        def form_fields
+          sign_fields
+        end
+
+        def customer(params = {})
+          add_field(mappings[:customer][:name], full_name(params))
+          add_field(mappings[:customer][:email], params[:email])
+          add_field(mappings[:customer][:phone], params[:phone])
+        end
+
+        def full_name(params)
+          return if params[:name].blank? && params[:first_name].blank? && params[:last_name].blank?
+
+          params[:name] || "#{params[:first_name]} #{params[:last_name]}"
+        end
+
+        def sign_fields
+          signature = Razorpay.sign(@fields, @key_secret)
+          @fields.merge!('signature' => signature)
+        end
+      end
+
+      class Notification < OffsitePayments::Notification
+
+        def initialize(post, options = {})
+          super
+          @key_secret = options[:credential2]
+        end
+
+        def item_id
+          params['merchant_order_id']
+        end
+
+        # Internal razorpay payment id
+        def transaction_id
+          params['razorpay_payment_id']
+        end
+
+        def currency
+          params['currency']
+        end
+
+        # the money amount we received in X.2 decimal.
+        # amount is in paise, so we divide it by 100
+        def gross
+          (params['amount'].to_i/100).to_f
+        end
+
+        def status
+          'Completed'
+        end
+
+        # Acknowledge the transaction to Razorpay. This method has to be called after a new
+        # apc arrives. Razorpay will verify that all the information we received are correct and will return a
+        # ok or a fail.
+        #
+        def acknowledge(authcode = nil)
+          parse(raw)
+          params['signature'] == generate_signature
+        end
+
+        def generate_signature
+          Razorpay.sign(params, @key_secret)
+        end
+
+        private
+
+        # Take the posted data and move the relevant data into a hash
+        def parse(post)
+          @raw = post.to_s
+          for line in @raw.split('&')
+            key, value = *line.scan( %r{^([A-Za-z0-9_.-]+)\=(.*)$} ).flatten
+            params[key] = CGI.unescape(value.to_s) if key.present?
+          end
+        end
+
+      end
+
+      class Return < OffsitePayments::Return
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -554,6 +554,10 @@ raven_pac_net:
   secret: "all good men die young"
   prn: 840033
 
+razorpay:
+  key_id: rzp_test_1DP5mmOlF5G5ag
+  key_secret: thisissupersecret
+
 realex:
   login: X
   password: Y

--- a/test/unit/integrations/razorpay/razorpay_helper_test.rb
+++ b/test/unit/integrations/razorpay/razorpay_helper_test.rb
@@ -1,0 +1,79 @@
+require 'test_helper'
+
+class RazorpayHelperTest < Test::Unit::TestCase
+  include OffsitePayments::Integrations
+
+  def setup
+    @key_id = fixtures(:razorpay)[:key_id]
+    @key_secret = fixtures(:razorpay)[:key_secret]
+    @helper = Razorpay::Helper.new('order_id',@key_id, 
+      :amount => 50.00,
+      :currency => 'INR',
+      :credential2=>@key_secret
+    )
+  end
+
+  def test_basic_helper_fields
+    # Note that amount is in paise now
+    assert_field 'amount', '5000'
+    assert_field 'currency', 'INR'
+    assert_field 'key', @key_id
+    assert_field 'merchant_order_id', 'order_id'
+  end
+
+  def test_customer_fields
+    @helper.customer :first_name => 'Abhay', :last_name => 'Rana', :email => 'nemo@razorpay.com', :phone => '1234567890'
+
+    assert_field 'prefill[name]',  'Abhay Rana'
+    assert_field 'prefill[email]', 'nemo@razorpay.com'
+    assert_field 'prefill[contact]', '1234567890'
+  end
+
+  def test_merchant_order_fields
+    @helper.country = 'India'
+    @helper.account_name = 'Razorpay Inc.'
+    @helper.description = 'Super Dev Badge'
+    @helper.invoice = 'Invoice #123'
+
+    assert_field 'notes[shop_country]', 'India'
+    assert_field 'name', 'Razorpay Inc.'
+    assert_field 'description', 'Super Dev Badge'
+    assert_field 'notes[invoice]', 'Invoice #123'
+  end
+
+  def test_shipping_fields
+    @helper.shipping_address :first_name => 'Abhay',
+      :last_name =>  'Rana',
+      :city =>       'San Francisco',
+      :company =>    'Facebook',
+      :address1 =>   '1 Hacker Way',
+      :address2 =>   'Facebook HQ',
+      :state =>      'California',
+      :zip =>        '94102',
+      :country =>    'USA',
+      :phone =>      '1234567890'
+    assert_field 'notes[shipping_first_name]', 'Abhay'
+    assert_field 'notes[shipping_last_name]',  'Rana'
+    assert_field 'notes[shipping_city]',       'San Francisco'
+    assert_field 'notes[shipping_company]',    'Facebook'
+    assert_field 'notes[shipping_address1]',   '1 Hacker Way'
+    assert_field 'notes[shipping_address2]',   'Facebook HQ'
+    assert_field 'notes[shipping_state]',      'California'
+    assert_field 'notes[shipping_zip]',        '94102'
+    assert_field 'notes[shipping_country]',    'US' # This is converted to Country Code internally
+    assert_field 'notes[shipping_phone]',   '1234567890'
+  end
+
+  def test_url_fields
+    @helper.return_url = 'https://checkout.razorpay.com/demo'
+    @helper.cancel_return_url = 'https://checkout.razorpay.com/demo/cancel'
+
+    assert_field 'url[callback]', 'https://checkout.razorpay.com/demo'
+    assert_field 'url[cancel]', 'https://checkout.razorpay.com/demo/cancel'
+  end
+
+  def test_signature
+    @helper.sign_fields
+    assert_field 'signature', '2dbc139e4033f21c847590bc3095f3f397b88b43'
+  end
+end

--- a/test/unit/integrations/razorpay/razorpay_module_test.rb
+++ b/test/unit/integrations/razorpay/razorpay_module_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class RazorpayTest < Test::Unit::TestCase
+  include OffsitePayments::Integrations
+
+  def test_notification_method
+    assert_instance_of Razorpay::Notification, Razorpay.notification("razorpay_payment_id=pay_2SQt8mN7tu2MIk")
+  end
+end

--- a/test/unit/integrations/razorpay/razorpay_notification_test.rb
+++ b/test/unit/integrations/razorpay/razorpay_notification_test.rb
@@ -1,0 +1,60 @@
+require 'test_helper'
+
+class RazorpayNotificationTest < Test::Unit::TestCase
+  include OffsitePayments::Integrations
+
+  def setup
+    @key_secret = fixtures(:razorpay)[:key_secret]
+    @razorpay = Razorpay::Notification.new(http_raw_data, :credential2=>@key_secret)
+  end
+
+  def test_accessors
+    assert_equal "Completed", @razorpay.status
+    assert_equal "pay_2Yfh8NYF0L66CD", @razorpay.transaction_id
+    assert_equal "INR", @razorpay.currency
+  end
+
+  def test_compositions
+    assert_equal Money.new(5000, 'INR'), @razorpay.amount
+  end
+
+  def test_gross
+    assert_equal 50.00, @razorpay.gross
+  end
+
+  # Replace with real successful acknowledgement code
+  def test_acknowledgement
+    assert @razorpay.acknowledge
+  end
+
+  def test_invalid_acknowledgement
+    razorpay = Razorpay::Notification.new(http_invalid_data, :credential2=>@key_secret)
+    assert_false razorpay.acknowledge
+  end
+
+  def test_respond_to_acknowledge
+    assert @razorpay.respond_to?(:acknowledge)
+  end
+
+  def test_status
+    assert_equal 'Completed', @razorpay.status
+  end
+
+  private
+  def http_raw_data
+    "razorpay_payment_id=pay_2Yfh8NYF0L66CD&\
+amount=5000&\
+currency=INR&\
+merchant_order_id=order_id&\
+signature=bcefe8e65bb11e0f23b68a5e00084612b186b71c\
+&http_status_code=200"
+  end
+
+  def http_invalid_data
+    "razorpay_payment_id=pay_2Yfh8NYF0L66CD&\
+amount=5000&\
+currency=INR&\
+merchant_order_id=order_id&\
+signature=bcefe8e65bb11e0f23b68a5e00084612b186b71d"
+  end
+end


### PR DESCRIPTION
Most of the code is boilerplate.

I have a few doubts regarding the integration:

- What kind of request is expected for a `Cancel` event. Do I just redirect (GET) to the url? Or should it be a POST with certain parameters. If POST, what are the required parameters?
- Is the `complete?` method required for a Notification

I'm also sending a mail to <payment-integrations@shopify.com> with the required details asked in the offsite-gateway-sim repo.