### PR TITLE
change path for test template when use generator

### DIFF
--- a/generators/integration_generator.rb
+++ b/generators/integration_generator.rb
@@ -18,9 +18,9 @@ class IntegrationGenerator < Thor::Group
   def generate
     template "templates/integration.rb", "#{lib}.rb"
 
-    template "templates/module_test.rb", "#{test_dir}/integrations/#{identifier}_module_test.rb"
-    template "templates/helper_test.rb", "#{test_dir}/integrations/#{identifier}_helper_test.rb"
-    template "templates/notification_test.rb", "#{test_dir}/integrations/#{identifier}_notification_test.rb"
+    template "templates/module_test.rb", "#{test_dir}/#{identifier}/#{identifier}_module_test.rb"
+    template "templates/helper_test.rb", "#{test_dir}/#{identifier}/#{identifier}_helper_test.rb"
+    template "templates/notification_test.rb", "#{test_dir}/#{identifier}/#{identifier}_notification_test.rb"
   end
 
   protected


### PR DESCRIPTION
it's strange when you generate the template and directory path for test is inside `integration` folder. Meanwhile, other payment gateway make it with their own name.
