### PR TITLE
Wirecard Checkout Page - Replace comma in payment amount with decimal point

### DIFF
--- a/lib/offsite_payments/integrations/wirecard_checkout_page.rb
+++ b/lib/offsite_payments/integrations/wirecard_checkout_page.rb
@@ -260,7 +260,7 @@ module OffsitePayments #:nodoc:
 
         # the money amount we received in X.2 decimal.
         def gross
-          params['amount']
+          params['amount'].sub!(',', '.')
         end
 
         # Was this a test transaction?


### PR DESCRIPTION
Otherwise rubys to_f method truncates the cents

```ruby
"100,50".to_f  => 100.0
"100.50".to_f  => 100.5
```