### PR TITLE
Revert "Make VendorTxCode unique"

### DIFF
--- a/lib/offsite_payments/integrations/sage_pay_form.rb
+++ b/lib/offsite_payments/integrations/sage_pay_form.rb
@@ -68,19 +68,14 @@ module OffsitePayments #:nodoc:
 
       class Helper < OffsitePayments::Helper
         include Encryption
-        attr_reader :timestamp
-
-        def initialize(order, account, options = {})
-          super
-          @timestamp = Time.now.strftime('%Y%m%d%H%M%S')
-          add_field 'VendorTxCode', "#{order}#{@timestamp}"
-        end
 
         mapping :credential2, 'EncryptKey'
 
         mapping :account, 'Vendor'
         mapping :amount, 'Amount'
         mapping :currency, 'Currency'
+
+        mapping :order, 'VendorTxCode'
 
         mapping :customer,
           :first_name => 'BillingFirstnames',

--- a/test/unit/integrations/sage_pay_form/sage_pay_form_helper_test.rb
+++ b/test/unit/integrations/sage_pay_form/sage_pay_form_helper_test.rb
@@ -24,7 +24,7 @@ class SagePayFormHelperTest < Test::Unit::TestCase
     assert_equal 5, @helper.fields.size
     assert_field 'Vendor', 'cody@example.com'
     assert_field 'Amount', '5.00'
-    assert_field 'VendorTxCode', 'order-500' + @helper.timestamp
+    assert_field 'VendorTxCode', 'order-500'
   end
 
   def test_customer_fields


### PR DESCRIPTION
Reverts activemerchant/offsite_payments#165

This revers the change makes the order number for sage pay out of range

>RangeError: 371608070920150904173138 is out of range for ActiveRecord::Type::Integer with limit 8

I propose we revert this and push them onto the [Hosted Payment SDK](https://docs.shopify.com/hosted-payment-sdk). I want to limit the amount of custom solutions we introduce to circumvent their incorrect handling of our checkout ids.

@girasquid @aprofeit 