### PR TITLE
Bump active_utils dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Offsite Payments CHANGELOG
 
+### Version 2.2.0 (October 14, 2015)
+- Bump active_utils dependency. [lucasuyezu]
+
 ### Version 2.1.0 (January 16, 2015)
 
 - **Change:** network exceptions now use ActiveUtils instead of ActiveMerchant as namespace,

--- a/lib/offsite_payments/version.rb
+++ b/lib/offsite_payments/version.rb
@@ -1,3 +1,3 @@
 module OffsitePayments
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end

--- a/offsite_payments.gemspec
+++ b/offsite_payments.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency('i18n', '~> 0.5')
   s.add_dependency('money', '< 7.0.0')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
-  s.add_dependency('active_utils', '~> 3.0.0')
+  s.add_dependency('active_utils', '~> 3.2.0')
   s.add_dependency('nokogiri', "~> 1.4")
   s.add_dependency('actionpack', ">= 3.2.20", "< 5.0.0")
 


### PR DESCRIPTION
We have moved some logic from Shopify to ActiveUtils [here](https://github.com/Shopify/active_utils/pull/64) and now in order to remove it from Shopify we need to bump this gem's dependency as well.