### PR TITLE
Allow to use this gem with Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,26 @@
 language: ruby
 script: "bundle exec rake test:units"
 sudo: false
+cache: bundler
 
 rvm:
-- "2.2"
-- "2.1"
-- "2.0"
-- "1.9"
+- 2.2.3
+- 2.1
+- 2.0
+- 1.9
 
 gemfile:
 - Gemfile.rails32
 - Gemfile.rails40
 - Gemfile.rails41
 - Gemfile.rails42
+- Gemfile.rails5
+
+matrix:
+  exclude:
+    - rvm: 1.9
+      gemfile: Gemfile.rails5
+    - rvm: 2.1
+      gemfile: Gemfile.rails5
+    - rvm: 2.0
+      gemfile: Gemfile.rails5

--- a/Gemfile.rails5
+++ b/Gemfile.rails5
@@ -1,0 +1,15 @@
+source 'https://rubygems.org'
+gemspec
+
+gem 'jruby-openssl', :platforms => :jruby
+gem 'money', '~> 5.0'
+
+group :remote_test do
+  gem 'mechanize'
+  gem 'launchy'
+  gem 'mongrel', '1.2.0.pre2', :platforms => :ruby
+end
+
+gem 'rails', github: 'rails/rails'
+gem 'arel', github: 'rails/arel'
+gem 'rack', github: 'rack/rack'

--- a/lib/offsite_payments.rb
+++ b/lib/offsite_payments.rb
@@ -3,8 +3,6 @@ require 'cgi'
 require "timeout"
 require "socket"
 
-require 'active_support/core_ext/class/delegating_attributes'
-
 require 'active_utils'
 
 require "offsite_payments/helper"

--- a/offsite_payments.gemspec
+++ b/offsite_payments.gemspec
@@ -22,13 +22,13 @@ Gem::Specification.new do |s|
   s.files = Dir['CHANGELOG', 'README.md', 'MIT-LICENSE', 'lib/**/*']
   s.require_path = 'lib'
 
-  s.add_dependency('activesupport', '>= 3.2.14', '< 5.0.0')
+  s.add_dependency('activesupport', '>= 3.2.14', '< 5.1')
   s.add_dependency('i18n', '~> 0.5')
   s.add_dependency('money', '< 7.0.0')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('active_utils', '~> 3.2.0')
   s.add_dependency('nokogiri', "~> 1.4")
-  s.add_dependency('actionpack', ">= 3.2.20", "< 5.0.0")
+  s.add_dependency('actionpack', ">= 3.2.20", "< 5.1")
 
   s.add_development_dependency('rake')
   s.add_development_dependency('test-unit', '~> 3.0')

--- a/test/unit/action_view_helper_test.rb
+++ b/test/unit/action_view_helper_test.rb
@@ -38,9 +38,7 @@ if "".respond_to? :html_safe?
     include ActionView::Helpers::TextHelper
   end
 
-  ::MissingSourceFile::REGEXPS << [/^cannot load such file -- (.+)$/i, 1]
   class PaymentServiceController < ActionController::Base
-
     def payment_action
       render :inline => "<% payment_service_for('order-1','test', :service => :bogus){} %>"
     end


### PR DESCRIPTION
The only required changes were to remove an unused require that was removed in Rails 5 and to change the gemspec to allow this gem to be installed with that version.