### PR TITLE
Make VendorTxCode unique with truncated timestamp

### DIFF
--- a/lib/offsite_payments/integrations/sage_pay_form.rb
+++ b/lib/offsite_payments/integrations/sage_pay_form.rb
@@ -69,13 +69,19 @@ module OffsitePayments #:nodoc:
       class Helper < OffsitePayments::Helper
         include Encryption
 
+        attr_reader :identifier
+
+        def initialize(order, account, options={})
+          super
+          @identifier = rand(0..99999).to_s.rjust(5, '0')
+          add_field 'VendorTxCode', "#{order}#{@identifier}"
+        end
+
         mapping :credential2, 'EncryptKey'
 
         mapping :account, 'Vendor'
         mapping :amount, 'Amount'
         mapping :currency, 'Currency'
-
-        mapping :order, 'VendorTxCode'
 
         mapping :customer,
           :first_name => 'BillingFirstnames',

--- a/test/unit/integrations/sage_pay_form/sage_pay_form_helper_test.rb
+++ b/test/unit/integrations/sage_pay_form/sage_pay_form_helper_test.rb
@@ -24,7 +24,11 @@ class SagePayFormHelperTest < Test::Unit::TestCase
     assert_equal 5, @helper.fields.size
     assert_field 'Vendor', 'cody@example.com'
     assert_field 'Amount', '5.00'
-    assert_field 'VendorTxCode', 'order-500'
+    assert_field 'VendorTxCode', 'order-500' + @helper.identifier
+  end
+
+  def test_identifier_should_only_contain_digits
+    assert_match /^[0-9]*$/, @helper.identifier
   end
 
   def test_customer_fields


### PR DESCRIPTION
Revises the reverted [Make VendorTxCode unique](https://github.com/activemerchant/offsite_payments/commit/ab81c120771dad4178398cc84e359a978a75e2a1) to truncate the timestamp to four characters to avoid integer out of bounds errors.

**Attn:**
@aprofeit @andrewpaliga @girasquid 