### PR TITLE
Send Billing Address for Universal Gateways

### DIFF
--- a/lib/offsite_payments/integrations/universal.rb
+++ b/lib/offsite_payments/integrations/universal.rb
@@ -105,6 +105,17 @@ module OffsitePayments #:nodoc:
                            :email      => 'x_customer_email',
                            :phone      => 'x_customer_phone'
 
+        mapping :billing_address, :first_name => 'x_customer_billing_first_name',
+                                  :last_name =>  'x_customer_billing_last_name',
+                                  :city =>       'x_customer_billing_city',
+                                  :company =>    'x_customer_billing_company',
+                                  :address1 =>   'x_customer_billing_address1',
+                                  :address2 =>   'x_customer_billing_address2',
+                                  :state =>      'x_customer_billing_state',
+                                  :zip =>        'x_customer_billing_zip',
+                                  :country =>    'x_customer_billing_country',
+                                  :phone =>      'x_customer_billing_phone'
+
         mapping :shipping_address, :first_name => 'x_customer_shipping_first_name',
                                    :last_name =>  'x_customer_shipping_last_name',
                                    :city =>       'x_customer_shipping_city',

--- a/test/unit/integrations/universal/universal_helper_test.rb
+++ b/test/unit/integrations/universal/universal_helper_test.rb
@@ -112,6 +112,30 @@ class UniversalHelperTest < Test::Unit::TestCase
     assert_field 'x_customer_shipping_phone',      '(416) 123-4567'
   end
 
+  def test_billing_address_fields
+    @helper.billing_address :first_name => 'John',
+                            :last_name  => 'Doe',
+                            :city       => 'Toronto',
+                            :company    => 'Shopify Toronto',
+                            :address1   => '241 Spadina Ave',
+                            :address2   => 'Front Entrance',
+                            :state      => 'ON',
+                            :zip        => 'M5T 3A8',
+                            :country    => 'CA',
+                            :phone      => '(416) 123-4567'
+
+    assert_field 'x_customer_billing_first_name', 'John'
+    assert_field 'x_customer_billing_last_name',  'Doe'
+    assert_field 'x_customer_billing_city',       'Toronto'
+    assert_field 'x_customer_billing_company',    'Shopify Toronto'
+    assert_field 'x_customer_billing_address1',   '241 Spadina Ave'
+    assert_field 'x_customer_billing_address2',   'Front Entrance'
+    assert_field 'x_customer_billing_state',      'ON'
+    assert_field 'x_customer_billing_zip',        'M5T 3A8'
+    assert_field 'x_customer_billing_country',    'CA'
+    assert_field 'x_customer_billing_phone',      '(416) 123-4567'
+  end
+
   def test_url_fields
     @helper.notify_url 'https://zork.com/notify'
     @helper.return_url 'https://zork.com/return'


### PR DESCRIPTION
Allow universal gateways to send their billing address as well as their shipping address.

**Attn:**
@aprofeit @andrewpaliga @girasquid 