### PR TITLE
App55: Remove Gateway

### DIFF
--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -11,10 +11,6 @@
 # Paste any required PEM certificates after the pem key.
 #
 
-app55:
-  api_key: "QDtACYMCFqtuKOQ22QtCkGR1TzD7XM8i"
-  api_secret: "yT1FRpuusBIQoEBIfIQ8bPStkl7yzdTz"
-
 authorize_net:
   login: X
   password: Y


### PR DESCRIPTION
The App55 Gateway is dead, this PR removes App55 from Offsite Payments.

* https://www.crunchbase.com/organization/app55#/entity
* http://www.app55.com/

**Attn:**
@girasquid @aprofeit @matthelm @berkcaputcu 