### PR TITLE
Stop testing ruby 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ rvm:
 - 2.2.3
 - 2.1
 - 2.0
-- 1.9
 
 gemfile:
 - Gemfile.rails32
@@ -18,8 +17,6 @@ gemfile:
 
 matrix:
   exclude:
-    - rvm: 1.9
-      gemfile: Gemfile.rails5
     - rvm: 2.1
       gemfile: Gemfile.rails5
     - rvm: 2.0


### PR DESCRIPTION
#### Changes
Ruby 1.9 is no longer supported as of [Feb 23](https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/) and our [CI builds are breaking](https://travis-ci.org/activemerchant/offsite_payments/builds/122329844) because some gems we use no longer support ruby 1.9. Let's not test for an unsupported ruby version any more.

#### Review
@girasquid @ThereExistsX