### PR TITLE
Inject loop not returning hash on guard clauses.

### DIFF
--- a/lib/offsite_payments/return.rb
+++ b/lib/offsite_payments/return.rb
@@ -25,9 +25,9 @@ module OffsitePayments #:nodoc:
       return {} if query_string.blank?
 
       query_string.split('&').inject({}) do |memo, chunk|
-        next if chunk.empty?
+        next memo if chunk.empty?
         key, value = chunk.split('=', 2)
-        next if key.empty?
+        next memo if key.empty?
         value = value.nil? ? nil : CGI.unescape(value)
         memo[CGI.unescape(key)] = value
         memo

--- a/test/unit/return_test.rb
+++ b/test/unit/return_test.rb
@@ -7,4 +7,17 @@ class ReturnTest < Test::Unit::TestCase
     r = Return.new('')
     assert r.success?
   end
+
+  def test_parse
+    r = Return.new('')
+    assert r.parse('account=test').is_a?(Hash)
+  end
+
+  def test_parse_with_bad_query
+    r = Return.new('')
+    assert r.parse('&account=test').is_a?(Hash)
+    assert r.parse('key1=value1&key2&key3=value3').is_a?(Hash)
+    assert r.parse('foooo=value1&=value&key3=value3').is_a?(Hash)
+    assert r.parse('key1=value1&&key3=value3').is_a?(Hash)
+  end
 end


### PR DESCRIPTION
Currently this will blow up if there is ever a query string with a nil key/value.

```
      query_string.split('&').inject({}) do |memo, chunk|
        next **memo** if chunk.empty?
        key, value = chunk.split('=', 2)
        next **memo** if key.empty?
        value = value.nil? ? nil : CGI.unescape(value)
        memo[CGI.unescape(key)] = value
        memo
      end
```

The bold fixes it.