### PR TITLE
Add x_message to Universal gateway

### DIFF
--- a/lib/offsite_payments/integrations/universal.rb
+++ b/lib/offsite_payments/integrations/universal.rb
@@ -163,6 +163,10 @@ module OffsitePayments #:nodoc:
           result && result.capitalize
         end
 
+        def message
+          @params['x_message']
+        end
+
         def test?
           @params['x_test'] == 'true'
         end
@@ -183,6 +187,10 @@ module OffsitePayments #:nodoc:
 
         def success?
           @notification.acknowledge
+        end
+
+        def message
+          @notification.message
         end
       end
     end

--- a/test/unit/integrations/universal/universal_notification_test.rb
+++ b/test/unit/integrations/universal/universal_notification_test.rb
@@ -14,6 +14,7 @@ class UniversalNotificationTest < Test::Unit::TestCase
     assert_equal '123.45', @notification.gross
     assert_equal 'blorb123', @notification.transaction_id
     assert_equal 'Completed', @notification.status
+    assert_equal 'helloworld', @notification.message
     assert @notification.test?
   end
 
@@ -46,7 +47,7 @@ class UniversalNotificationTest < Test::Unit::TestCase
   private
 
   def http_raw_data
-    'x_account_id=zork&x_reference=order-500&x_currency=USD&x_test=true&x_amount=123.45&x_gateway_reference=blorb123&x_timestamp=2014-03-24T12:15:41Z&x_result=completed&x_signature=d8797220f2f0ccef90c1ee80e82494cd709fb10ab1f50a016578208c3fb5a0c1'
+    'x_account_id=zork&x_reference=order-500&x_currency=USD&x_test=true&x_amount=123.45&x_gateway_reference=blorb123&x_timestamp=2014-03-24T12:15:41Z&x_result=completed&x_signature=82b635305a18e3e614c473ab4dce900a7c00db79bd68525e565a29ff69218f37&x_message=helloworld'
   end
 
   def http_raw_data_extra_parameter

--- a/test/unit/integrations/universal/universal_return_test.rb
+++ b/test/unit/integrations/universal/universal_return_test.rb
@@ -23,9 +23,13 @@ class UniversalReturnTest < Test::Unit::TestCase
     assert @return.success?
   end
 
+  def test_return_message
+    assert_equal 'helloworld', @return.message
+  end
+
   private
 
   def query_data
-    'x_account_id=zork&x_reference=order-500&x_currency=USD&x_test=true&x_amount=123.45&x_gateway_reference=blorb123&x_timestamp=2014-03-24T12:15:41Z&x_result=success&x_signature=4365fef32f5309845052b728c8cbe962e583ecaf62bf1cdec91f248162b7f65e'
+    'x_account_id=zork&x_reference=order-500&x_currency=USD&x_test=true&x_amount=123.45&x_gateway_reference=blorb123&x_timestamp=2014-03-24T12:15:41Z&x_result=success&x_signature=55bd5acfabe65041568a94cb8981489ebced1f1eceebe0b985c8db43f3fedf91&x_message=helloworld'
   end
 end


### PR DESCRIPTION
This makes it so that `Universal` gateways can include `x_message` in payload to Shopify. We need this for [COD app](https://github.com/Shopify/cod-app) so that it to return a custom failure message upon payment failure. @aprofeit let me know if this makes sense or if there's a better way to do this somewhere. cc @quelledanielle @kyledurand