### PR TITLE
Update Dutch banks for Mollie iDEAL 🇳🇱

### DIFF
--- a/lib/offsite_payments/integrations/mollie_ideal.rb
+++ b/lib/offsite_payments/integrations/mollie_ideal.rb
@@ -7,7 +7,7 @@ module OffsitePayments #:nodoc:
       self.live_issuers = [
         ["ABN AMRO", "ideal_ABNANL2A"],
         ["ASN Bank", "ideal_ASNBNL21"],
-        ["Friesland Bank", "ideal_FRBKNL2L"],
+        ["Bunq", "ideal_BUNQNL2A"],
         ["ING", "ideal_INGBNL2A"],
         ["Knab", "ideal_KNABNL2H"],
         ["Rabobank", "ideal_RABONL2U"],


### PR DESCRIPTION
Friesland Bank has been taken over by Rabobank and was shut down in 2013: https://www.rabobank.nl/particulieren/frieslandbank/

Bunq is a new bank that acquired its license in 2015: https://www.nrc.nl/nieuws/2015/11/25/bunq-whatsapp-voor-banken-1559753-a310271