### PR TITLE
Send digits only phone to PayU

### DIFF
--- a/lib/offsite_payments/integrations/payu_in.rb
+++ b/lib/offsite_payments/integrations/payu_in.rb
@@ -84,7 +84,8 @@ module OffsitePayments #:nodoc:
         end
 
         def sanitize_fields
-          ['address1', 'address2', 'city', 'state', 'country', 'productinfo', 'email', 'phone'].each do |field|
+          @fields['phone'].gsub!(/[^0-9]/, '') if @fields['phone']
+          ['address1', 'address2', 'city', 'state', 'country', 'productinfo', 'email'].each do |field|
             @fields[field].gsub!(/[^a-zA-Z0-9\-_@\/\s.]/, '') if @fields[field]
           end
         end

--- a/test/unit/integrations/payu_in/payu_in_helper_test.rb
+++ b/test/unit/integrations/payu_in/payu_in_helper_test.rb
@@ -71,4 +71,8 @@ class PayuInHelperTest < Test::Unit::TestCase
     assert_nil @helper.fields['email']
   end
 
+  def test_phone_replace_non_digits
+    @helper.fields['phone'] = '+(999)-99 99999'
+    assert_equal '9999999999', @helper.form_fields['phone']
+  end
 end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Right now, phone field is sent as a basic string to PayU and includes spaces and other characters. The problem is that PayU doesn't allow users to pay if the phone numbers is not digits only.

See this screenshot where the phone is filled but PayU doesn't show any error, it just grays out the pay button.

![68747470733a2f2f73637265656e73686f742e636c69636b2f62703974662e706e67](https://cloud.githubusercontent.com/assets/445045/21108272/a86bc3ea-c062-11e6-82d2-48ce30560524.png)

When removing the space, everything works as expected.

![68747470733a2f2f73637265656e73686f742e636c69636b2f6f676c30382e706e67](https://cloud.githubusercontent.com/assets/445045/21108316/cb3364aa-c062-11e6-918d-4797b291c368.png)

**How is this accomplished?**
Add a specific regex to sanatize phone fields.

@pi3r @jasonwebster 