### PR TITLE
removes minimum money dependency

### DIFF
--- a/offsite_payments.gemspec
+++ b/offsite_payments.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('activesupport', '>= 3.2.14', '< 5.1')
   s.add_dependency('i18n', '~> 0.5')
-  s.add_dependency('money', '~> 6.0')
+  s.add_dependency('money', '< 7.0.0')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('active_utils', '~> 3.2.0')
   s.add_dependency('nokogiri', "~> 1.4")


### PR DESCRIPTION
minimal version conflicts with https://github.com/Shopify/money