### PR TITLE
[Realex] guard against nil when extracting AVS code

### DIFF
--- a/lib/offsite_payments/integrations/realex_offsite.rb
+++ b/lib/offsite_payments/integrations/realex_offsite.rb
@@ -88,6 +88,7 @@ module OffsitePayments #:nodoc:
         end
 
         def extract_digits(value)
+          return unless value
           value.scan(/\d+/).join('')
         end
 


### PR DESCRIPTION
This simply adds a guard against nils being passed into the digit extraction method. 
Address data is not guaranteed to be part of incoming parameters, which causes `extract_digits` to throw exceptions. 