### PR TITLE
realex_offsite to_f rounding error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,6 @@ matrix:
       gemfile: Gemfile.rails41
     - rvm: 2.4.0
       gemfile: Gemfile.rails42
+
+before_install:
+  - gem update bundler

--- a/lib/offsite_payments.rb
+++ b/lib/offsite_payments.rb
@@ -2,6 +2,8 @@ require 'securerandom'
 require 'cgi'
 require "timeout"
 require "socket"
+require 'bigdecimal'
+require 'bigdecimal/util'
 
 require 'active_utils'
 

--- a/lib/offsite_payments/integrations/realex_offsite.rb
+++ b/lib/offsite_payments/integrations/realex_offsite.rb
@@ -71,20 +71,20 @@ module OffsitePayments #:nodoc:
         end
 
         # Realex accepts currency amounts as an integer in the lowest value
-        # e.g. 
+        # e.g.
         #     format_amount(110.56, 'GBP')
         #     => 11056
         def format_amount(amount, currency)
           units = CURRENCY_SPECIAL_MINOR_UNITS[currency] || 2
           multiple = 10**units
-          return (amount.to_f * multiple.to_f).to_i
+          return ((amount || 0).to_d * multiple.to_d).to_i
         end
 
         # Realex returns currency amount as an integer
         def format_amount_as_float(amount, currency)
           units = CURRENCY_SPECIAL_MINOR_UNITS[currency] || 2
           divisor = 10**units
-          return (amount.to_f / divisor.to_f)
+          return ((amount || 0).to_d / divisor.to_d)
         end
 
         def extract_digits(value)

--- a/test/unit/integrations/realex_offsite/realex_offsite_helper_test.rb
+++ b/test/unit/integrations/realex_offsite/realex_offsite_helper_test.rb
@@ -67,11 +67,18 @@ class RealexOffsiteHelperTest < Test::Unit::TestCase
   end
 
   def test_format_amount_as_float
-    amount_gbp = @helper.format_amount_as_float(999, 'GBP')
-    assert_in_delta amount_gbp, 9.99, 0.00
+    amount_gbp = @helper.format_amount_as_float(929, 'GBP')
+    assert_in_delta amount_gbp, 9.29, 0.00
 
-    amount_bhd = @helper.format_amount_as_float(999, 'BHD')
-    assert_in_delta amount_bhd, 0.999, 0.00
+    amount_bhd = @helper.format_amount_as_float(929, 'BHD')
+    assert_in_delta amount_bhd, 0.929, 0.00
   end
 
+  def test_format_amount
+    amount_gbp = @helper.format_amount('9.29', 'GBP')
+    assert_equal amount_gbp, 929
+
+    amount_bhd = @helper.format_amount(0.929, 'BHD')
+    assert_equal amount_bhd, 929
+  end
 end


### PR DESCRIPTION
**Why**
```ruby
(9.29.to_f * 100).to_i == 928
```

**What**
Use decimals instead of floats. Also added a regression test

**More info**
http://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html