### PR TITLE
Constrain dependency according to Rails' shifted semver

### DIFF
--- a/offsite_payments.gemspec
+++ b/offsite_payments.gemspec
@@ -22,13 +22,13 @@ Gem::Specification.new do |s|
   s.files = Dir['CHANGELOG', 'README.md', 'MIT-LICENSE', 'lib/**/*']
   s.require_path = 'lib'
 
-  s.add_dependency('activesupport', '>= 3.2.14', '< 6.x')
+  s.add_dependency('activesupport', '>= 3.2.14', '< 5.2')
   s.add_dependency('i18n', '~> 0.5')
   s.add_dependency('money', '< 7.0.0')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('active_utils', '~> 3.3.0')
   s.add_dependency('nokogiri', "~> 1.6")
-  s.add_dependency('actionpack', '>= 3.2.20', '< 6.x')
+  s.add_dependency('actionpack', '>= 3.2.20', '< 5.2')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('test-unit', '~> 3.0')


### PR DESCRIPTION
Per @rafaelfranca's (a member of the Rails core team) comment[1]:
>I'd not do this. 5.2 may contains breaking changes, usually for gems of this size it works, but the Rails team doesn't recommend to use the same rules as the semver since we use shifted semver.

1: https://github.com/activemerchant/offsite_payments/commit/cc772fdf6115ce2a4bbc73c99b58a70f60908a28#commitcomment-22021971