### PR TITLE
Replace Money.new with Money.from_amount

### DIFF
--- a/generators/templates/notification_test.rb
+++ b/generators/templates/notification_test.rb
@@ -19,7 +19,7 @@ class <%= class_name %>NotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(3166, 'USD'), @<%= identifier %>.amount
+    assert_equal Money.from_amount(31.66, 'USD'), @<%= identifier %>.amount
   end
 
   # Replace with real successful acknowledgement code

--- a/lib/offsite_payments/integrations/epay.rb
+++ b/lib/offsite_payments/integrations/epay.rb
@@ -125,7 +125,7 @@ module OffsitePayments #:nodoc:
           return false
         end
 
-        %w(txnid orderid amount currency date time hash fraud payercountry issuercountry txnfee subscriptionid paymenttype cardno).each do |attr|
+        %w(txnid orderid currency date time hash fraud payercountry issuercountry txnfee subscriptionid paymenttype cardno).each do |attr|
           define_method(attr) do
             params[attr]
           end
@@ -133,10 +133,6 @@ module OffsitePayments #:nodoc:
 
         def currency
           CURRENCY_CODES.invert[params['currency']].to_s
-        end
-
-        def amount
-          Money.new(params['amount'].to_i, currency)
         end
 
         def generate_md5string

--- a/lib/offsite_payments/notification.rb
+++ b/lib/offsite_payments/notification.rb
@@ -30,11 +30,10 @@ module OffsitePayments #:nodoc:
       (gross.to_f * 100.0).round
     end
 
-    # This combines the gross and currency and returns a proper Money object.
-    # this requires the money library located at http://rubymoney.github.io/money/
     def amount
-      return Money.new(gross_cents, currency) rescue ArgumentError
-      return Money.new(gross_cents) # maybe you have an own money object which doesn't take a currency?
+      amount = gross ? gross.to_d : 0
+      return Money.from_amount(amount, currency) rescue ArgumentError
+      return Money.from_amount(amount) # maybe you have an own money object which doesn't take a currency?
     end
 
     # reset the notification.

--- a/test/unit/integrations/a1agregator/a1agregator_notification_test.rb
+++ b/test/unit/integrations/a1agregator/a1agregator_notification_test.rb
@@ -23,7 +23,7 @@ class A1agregatorNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(10000, 'RUB'), @a1agregator.amount
+    assert_equal Money.from_amount(100.00, 'RUB'), @a1agregator.amount
   end
 
   def test_acknowledgement

--- a/test/unit/integrations/authorize_net_sim/authorize_net_sim_notification_test.rb
+++ b/test/unit/integrations/authorize_net_sim/authorize_net_sim_notification_test.rb
@@ -26,7 +26,7 @@ class AuthorizeNetSimNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(12100, 'USD'), @authorize_net_sim.amount
+    assert_equal Money.from_amount(121.00, 'USD'), @authorize_net_sim.amount
   end
 
   def test_accessors_when_set

--- a/test/unit/integrations/bit_pay/bit_pay_notification_test.rb
+++ b/test/unit/integrations/bit_pay/bit_pay_notification_test.rb
@@ -32,7 +32,7 @@ class BitPayNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(1000, 'USD'), @bit_pay.amount
+    assert_equal Money.from_amount(10.00, 'USD'), @bit_pay.amount
   end
 
   def test_successful_acknowledgement

--- a/test/unit/integrations/chronopay/chronopay_notification_test.rb
+++ b/test/unit/integrations/chronopay/chronopay_notification_test.rb
@@ -41,7 +41,7 @@ class ChronopayNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(50000, 'CAD'), @notification.amount
+    assert_equal Money.from_amount(500.00, 'CAD'), @notification.amount
   end
 
   def test_payment_successful_status

--- a/test/unit/integrations/direc_pay/direc_pay_notification_test.rb
+++ b/test/unit/integrations/direc_pay/direc_pay_notification_test.rb
@@ -37,7 +37,7 @@ class DirecPayNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(100, 'INR'), @direc_pay.amount
+    assert_equal Money.from_amount(1.00, 'INR'), @direc_pay.amount
   end
 
   def test_acknowledgement

--- a/test/unit/integrations/direc_pay/direc_pay_return_test.rb
+++ b/test/unit/integrations/direc_pay/direc_pay_return_test.rb
@@ -28,7 +28,7 @@ class DirecPayReturnTest < Test::Unit::TestCase
     assert_equal '1001', notification.item_id
     assert_equal '1.00', notification.gross
     assert_equal 100, notification.gross_cents
-    assert_equal Money.new(100, 'INR'), notification.amount
+    assert_equal Money.from_amount(1.00, 'INR'), notification.amount
     assert_equal 'INR', notification.currency
     assert_equal 'IND', notification.country
     assert_equal 'NULL', notification.other_details

--- a/test/unit/integrations/directebanking/directebanking_notification_test.rb
+++ b/test/unit/integrations/directebanking/directebanking_notification_test.rb
@@ -19,7 +19,7 @@ class DirectebankingNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(100, 'EUR'), @deb.amount
+    assert_equal Money.from_amount(1.00, 'EUR'), @deb.amount
   end
 
   def test_acknowledgement

--- a/test/unit/integrations/dotpay/dotpay_notification_test.rb
+++ b/test/unit/integrations/dotpay/dotpay_notification_test.rb
@@ -30,7 +30,7 @@ class DotpayNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(15000, 'PLN'), @dotpay.amount
+    assert_equal Money.from_amount(150.00, 'PLN'), @dotpay.amount
   end
 
   # Replace with real successful acknowledgement code

--- a/test/unit/integrations/dwolla/dwolla_notification_test.rb
+++ b/test/unit/integrations/dwolla/dwolla_notification_test.rb
@@ -28,7 +28,7 @@ class DwollaNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(1, 'USD'), @success.amount
+    assert_equal Money.from_amount(0.01, 'USD'), @success.amount
   end
 
   # Replace with real successful acknowledgement code

--- a/test/unit/integrations/easy_pay/easy_pay_notification_test.rb
+++ b/test/unit/integrations/easy_pay/easy_pay_notification_test.rb
@@ -14,7 +14,7 @@ class EasyPayNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.from_amount(BigDecimal.new('100'), 'BYR'), @easypay.amount
+    assert_equal Money.from_amount(BigDecimal.new('100.00'), 'BYR'), @easypay.amount
   end
 
   def test_credential2_required

--- a/test/unit/integrations/epay/epay_notification_test.rb
+++ b/test/unit/integrations/epay/epay_notification_test.rb
@@ -18,7 +18,7 @@ class EpayNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(398750, 'DKK'), @epay.amount
+    assert_equal Money.from_amount(3987.50, 'DKK'), @epay.amount
   end
 
   def test_acknowledgement

--- a/test/unit/integrations/first_data/first_data_notification_test.rb
+++ b/test/unit/integrations/first_data/first_data_notification_test.rb
@@ -28,7 +28,7 @@ class FirstDataNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(12100, 'USD'), @first_data.amount
+    assert_equal Money.from_amount(121.00, 'USD'), @first_data.amount
   end
 
   def test_accessors_when_set

--- a/test/unit/integrations/gestpay/gestpay_notification_test.rb
+++ b/test/unit/integrations/gestpay/gestpay_notification_test.rb
@@ -13,7 +13,7 @@ class GestpayNotificationTest < Test::Unit::TestCase
     assert_equal "1000", notification.item_id
     assert_equal "1234.56", notification.gross
     assert_equal "EUR", notification.currency
-    assert_equal Money.new(123456, 'EUR'), notification.amount
+    assert_equal Money.from_amount(1234.56, 'EUR'), notification.amount
   end
 
   def test_failed_notification

--- a/test/unit/integrations/hi_trust/hi_trust_notification_test.rb
+++ b/test/unit/integrations/hi_trust/hi_trust_notification_test.rb
@@ -24,7 +24,7 @@ class HiTrustNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(500, 'USD'), @notification.amount
+    assert_equal Money.from_amount(5.00, 'USD'), @notification.amount
   end
 
   def test_send_acknowledgement

--- a/test/unit/integrations/klarna/klarna_notification_test.rb
+++ b/test/unit/integrations/klarna/klarna_notification_test.rb
@@ -24,7 +24,7 @@ class KlarnaNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(5000, 'SEK'), @klarna.amount
+    assert_equal Money.from_amount(50.00, 'SEK'), @klarna.amount
   end
 
   def test_acknowledge

--- a/test/unit/integrations/mollie_ideal/mollie_ideal_notification_test.rb
+++ b/test/unit/integrations/mollie_ideal/mollie_ideal_notification_test.rb
@@ -24,7 +24,7 @@ class MollieIdealNotificationTest < Test::Unit::TestCase
     assert_equal "EUR", @notification.currency
     assert_equal 12345, @notification.gross_cents
     assert_equal "123.45", @notification.gross
-    assert_equal Money.new(12345, 'EUR'), @notification.amount
+    assert_equal Money.from_amount(123.45, 'EUR'), @notification.amount
 
     assert_equal "123", @notification.item_id
   end

--- a/test/unit/integrations/mollie_mistercash/mollie_mistercash_notification_test.rb
+++ b/test/unit/integrations/mollie_mistercash/mollie_mistercash_notification_test.rb
@@ -24,7 +24,7 @@ class MollieMistercashNotificationTest < Test::Unit::TestCase
     assert_equal "EUR", @notification.currency
     assert_equal 12345, @notification.gross_cents
     assert_equal "123.45", @notification.gross
-    assert_equal Money.new(12345, 'EUR'), @notification.amount
+    assert_equal Money.from_amount(123.45, 'EUR'), @notification.amount
 
     assert_equal "123", @notification.item_id
   end

--- a/test/unit/integrations/moneybookers/moneybookers_notification_test.rb
+++ b/test/unit/integrations/moneybookers/moneybookers_notification_test.rb
@@ -20,7 +20,7 @@ class MoneybookersNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(3960, 'EUR'), @moneybookers.amount
+    assert_equal Money.from_amount(39.60, 'EUR'), @moneybookers.amount
   end
 
   def test_respond_to_acknowledge

--- a/test/unit/integrations/nochex/nochex_notification_test.rb
+++ b/test/unit/integrations/nochex/nochex_notification_test.rb
@@ -19,7 +19,7 @@ class NochexNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(3166, 'GBP'), @nochex.amount
+    assert_equal Money.from_amount(31.66, 'GBP'), @nochex.amount
   end
 
   def test_successful_acknowledgement

--- a/test/unit/integrations/pag_seguro/pag_seguro_notification_test.rb
+++ b/test/unit/integrations/pag_seguro/pag_seguro_notification_test.rb
@@ -27,7 +27,7 @@ class PagSeguroNotificationTest < Test::Unit::TestCase
   def test_compositions
     Net::HTTP.expects(:get_response).with(@uri).returns(stub(code: "200", body: http_raw_data))
     pag_seguro = PagSeguro::Notification.new(notification_data)
-    assert_equal Money.new(4912, 'BRL'), pag_seguro.amount
+    assert_equal Money.from_amount(49.12, 'BRL'), pag_seguro.amount
   end
 
   def test_respond_to_acknowledge

--- a/test/unit/integrations/paydollar/paydollar_notification_test.rb
+++ b/test/unit/integrations/paydollar/paydollar_notification_test.rb
@@ -18,7 +18,7 @@ class PaydollarNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(13962, 'HKD'), @paydollar.amount
+    assert_equal Money.from_amount(139.62, 'HKD'), @paydollar.amount
   end
 
   def test_acknowledgement

--- a/test/unit/integrations/paypal/paypal_notification_test.rb
+++ b/test/unit/integrations/paypal/paypal_notification_test.rb
@@ -57,7 +57,7 @@ class PaypalNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(50000, 'CAD'), @paypal.amount
+    assert_equal Money.from_amount(500.00, 'CAD'), @paypal.amount
   end
 
   def test_acknowledgement

--- a/test/unit/integrations/paytm/paytm_notification_test.rb
+++ b/test/unit/integrations/paytm/paytm_notification_test.rb
@@ -19,7 +19,7 @@ class PaytmNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(12345, 'USD'), @notification.amount
+    assert_equal Money.from_amount(123.45, 'USD'), @notification.amount
   end
 
   def test_acknowledge_valid_signature

--- a/test/unit/integrations/quickpay/quickpay_notification_test.rb
+++ b/test/unit/integrations/quickpay/quickpay_notification_test.rb
@@ -18,7 +18,7 @@ class QuickpayNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(123, 'DKK'), @quickpay.amount
+    assert_equal Money.from_amount(1.23, 'DKK'), @quickpay.amount
   end
 
   def test_acknowledgement

--- a/test/unit/integrations/realex_offsite/realex_offsite_notification_test.rb
+++ b/test/unit/integrations/realex_offsite/realex_offsite_notification_test.rb
@@ -21,7 +21,7 @@ class RealexOffsiteNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(5000, 'USD'), @notification.amount
+    assert_equal Money.from_amount(50.00, 'USD'), @notification.amount
   end
 
   def test_test_mode

--- a/test/unit/integrations/robokassa/robokassa_notification_test.rb
+++ b/test/unit/integrations/robokassa/robokassa_notification_test.rb
@@ -14,7 +14,7 @@ class RobokassaNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(50000, 'RUB'), @robokassa.amount
+    assert_equal Money.from_amount(500.00, 'RUB'), @robokassa.amount
   end
 
   # Replace with real successful acknowledgement code

--- a/test/unit/integrations/sage_pay_form/sage_pay_form_notification_test.rb
+++ b/test/unit/integrations/sage_pay_form/sage_pay_form_notification_test.rb
@@ -97,7 +97,7 @@ class SagePayFormNotificationTest < Test::Unit::TestCase
 
   def test_compositions
     n = SagePayForm::Notification.new(successful_purchase, @options)
-    assert_equal Money.new(123147, nil), n.amount
+    assert_equal Money.from_amount(1231.47), n.amount
   end
 
   def test_bogus_crypt

--- a/test/unit/integrations/two_checkout/two_checkout_notification_test.rb
+++ b/test/unit/integrations/two_checkout/two_checkout_notification_test.rb
@@ -21,7 +21,7 @@ class TwoCheckoutNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(20, 'USD'), @live_notification.amount
+    assert_equal Money.from_amount(0.20, 'USD'), @live_notification.amount
   end
 
   def test_acknowledgement

--- a/test/unit/integrations/universal/universal_notification_test.rb
+++ b/test/unit/integrations/universal/universal_notification_test.rb
@@ -19,7 +19,7 @@ class UniversalNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(12345, 'USD'), @notification.amount
+    assert_equal Money.from_amount(123.45, 'USD'), @notification.amount
   end
 
   def test_acknowledge_valid_signature

--- a/test/unit/integrations/webmoney/webmoney_notification_test.rb
+++ b/test/unit/integrations/webmoney/webmoney_notification_test.rb
@@ -13,7 +13,7 @@ class WebmoneyNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.from_amount(1, 'RUB'), @webmoney.amount
+    assert_equal Money.from_amount(1.00, 'RUB'), @webmoney.amount
   end
 
   def test_acknowledgement

--- a/test/unit/integrations/world_pay/world_pay_notification_test.rb
+++ b/test/unit/integrations/world_pay/world_pay_notification_test.rb
@@ -19,7 +19,7 @@ class WorldPayNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.new(500, 'GBP'), @world_pay.amount
+    assert_equal Money.from_amount(5.00, 'GBP'), @world_pay.amount
   end
 
   def test_extra_accessors
@@ -66,7 +66,7 @@ class WorldPayNotificationTest < Test::Unit::TestCase
   end
 
   def test_valid_sender
-    OffsitePayments.mode = :production 
+    OffsitePayments.mode = :production
     assert @world_pay.valid_sender?('195.35.90.0')
     assert @world_pay.valid_sender?('195.35.90.11')
     assert @world_pay.valid_sender?('195.35.91.255')


### PR DESCRIPTION
## What
Use `Money.from_amount` with a decimal value instead of `Money.new`

## Why
Different Money gems handle `.new` in different ways (either with cents or dollars). To be explicit it is preferred to use `from_amount` which always expects the decimal amount value (dollars).