### PR TITLE
	Remove stray curly bracket

### DIFF
--- a/lib/offsite_payments/integrations/mollie.rb
+++ b/lib/offsite_payments/integrations/mollie.rb
@@ -14,7 +14,7 @@ module OffsitePayments #:nodoc:
 
         def get_request(resource, params = nil)
           uri = URI.parse(MOLLIE_API_V1_URI + resource)
-          uri.query = params.map { |k,v| "#{CGI.escape(k)}=#{CGI.escape(v)}}"}.join('&') if params
+          uri.query = params.map { |k,v| "#{CGI.escape(k)}=#{CGI.escape(v)}"}.join('&') if params
           headers = { "Authorization" => "Bearer #{token}", "Content-Type" => "application/json" }
           JSON.parse(ssl_get(uri.to_s, headers))
         end


### PR DESCRIPTION
This curly bracket causes issues when calling the Mollie API with extra parameters.