### PR TITLE
replace to_f with to_d

### DIFF
--- a/lib/offsite_payments/integrations/authorize_net_sim.rb
+++ b/lib/offsite_payments/integrations/authorize_net_sim.rb
@@ -189,7 +189,7 @@ module OffsitePayments #:nodoc:
           quantity = options[:quantity] || 1
           line_title = options[:line_title] || ('Item ' + (@line_item_count + 1).to_s) # left most field
           unit_price = options[:unit_price] || 0
-          unit_price = unit_price.to_f.round(2)
+          unit_price = unit_price.to_d.round(2)
           tax_value = options[:tax_value] || 'N'
 
           # Sanitization, in case they include a reserved word here, following
@@ -200,7 +200,7 @@ module OffsitePayments #:nodoc:
           raise 'illegal char for line item <|>' if name.include? '<|>'
           raise 'illegal char for line item "' if name.include? '"'
           raise 'cannot pass in dollar sign' if unit_price.to_s.include? '$'
-          raise 'must have positive or 0 unit price' if unit_price.to_f < 0
+          raise 'must have positive or 0 unit price' if unit_price.to_d < 0
           # Using CGI::escape causes the output to be formated incorrectly in
           # the HTML presented to the end-user's browser (e.g., spaces turn
           # into +'s).
@@ -242,7 +242,7 @@ module OffsitePayments #:nodoc:
           add_field 'x_duplicate_window', '28800' # large default duplicate window.
           add_field 'x_currency_code', currency_code
           add_field 'x_version' , '3.1' # version from doc
-          add_field 'x_amount', options[:amount].to_f.round(2)
+          add_field 'x_amount', options[:amount].to_d.round(2)
           @line_item_count = 0
         end
       end
@@ -258,7 +258,7 @@ module OffsitePayments #:nodoc:
       #   return render :partial => 'authorize_net_sim_payment_response'
       # end
       #
-      # if order.total != parser.gross.to_f
+      # if order.total != parser.gross.to_d
       #   logger.error "Authorize.Net sim said they paid for #{parser.gross} and it should have been #{order.total}!"
       #   passed = false
       # end

--- a/lib/offsite_payments/integrations/bit_pay.rb
+++ b/lib/offsite_payments/integrations/bit_pay.rb
@@ -113,7 +113,7 @@ module OffsitePayments #:nodoc:
         end
 
         def gross
-          params['price'].to_f
+          params['price'].to_d
         end
 
         def acknowledge(authcode = nil)

--- a/lib/offsite_payments/integrations/coinbase.rb
+++ b/lib/offsite_payments/integrations/coinbase.rb
@@ -82,9 +82,9 @@ module OffsitePayments #:nodoc:
 
         def gross
           if params['total_original'].present?
-            "%.2f" % (params['total_original']['cents'].to_f / 100)
+            "%.2f" % (params['total_original']['cents'].to_d / 100)
           else
-            "%.2f" % (params['total_native']['cents'].to_f / 100)
+            "%.2f" % (params['total_native']['cents'].to_d / 100)
           end
         end
 

--- a/lib/offsite_payments/integrations/direc_pay.rb
+++ b/lib/offsite_payments/integrations/direc_pay.rb
@@ -101,7 +101,7 @@ module OffsitePayments #:nodoc:
           raise ArgumentError, "amount must be a Money object or an integer" if money.is_a?(String)
           raise ActionViewHelperError, "amount must be greater than $0.00" if cents.to_i <= 0
 
-          add_field(mappings[:amount], sprintf("%.2f", cents.to_f/100))
+          add_field(mappings[:amount], sprintf("%.2f", cents.to_d/100))
         end
 
         def shipping_address(params = {})

--- a/lib/offsite_payments/integrations/directebanking.rb
+++ b/lib/offsite_payments/integrations/directebanking.rb
@@ -93,7 +93,7 @@ module OffsitePayments #:nodoc:
           raise ArgumentError, "amount must be a Money object or an integer" if money.is_a?(String)
           raise ActionViewHelperError, "amount must be greater than $0.00" if cents.to_i <= 0
 
-          add_field mappings[:amount], sprintf("%.2f", cents.to_f/100)
+          add_field mappings[:amount], sprintf("%.2f", cents.to_d/100)
         end
 
         def generate_signature_string
@@ -146,7 +146,7 @@ module OffsitePayments #:nodoc:
 
         # the money amount we received in X.2 decimal.
         def gross
-          "%.2f" % params['amount'].to_f
+          "%.2f" % params['amount'].to_d
         end
 
         def status

--- a/lib/offsite_payments/integrations/hi_trust.rb
+++ b/lib/offsite_payments/integrations/hi_trust.rb
@@ -90,7 +90,7 @@ module OffsitePayments #:nodoc:
         end
 
         def gross
-          sprintf("%.2f", gross_cents.to_f / 100)
+          sprintf("%.2f", gross_cents.to_d / 100)
         end
 
         def gross_cents

--- a/lib/offsite_payments/integrations/ipay88.rb
+++ b/lib/offsite_payments/integrations/ipay88.rb
@@ -62,7 +62,7 @@ module OffsitePayments #:nodoc:
         end
 
         def amount_in_dollars
-          sprintf("%.2f", @amount_in_cents.to_f/100)
+          sprintf("%.2f", @amount_in_cents.to_d/100)
         end
 
         def amount=(money)

--- a/lib/offsite_payments/integrations/klarna.rb
+++ b/lib/offsite_payments/integrations/klarna.rb
@@ -160,8 +160,8 @@ module OffsitePayments #:nodoc:
         end
 
         def tax_rate_for(item)
-          subtotal_price = item.fetch(:unit_price, 0).to_f * item.fetch(:quantity, 0).to_i
-          tax_amount = item.fetch(:tax_amount, 0).to_f
+          subtotal_price = item.fetch(:unit_price, 0).to_d * item.fetch(:quantity, 0).to_i
+          tax_amount = item.fetch(:tax_amount, 0).to_d
 
           if subtotal_price > 0
             tax_rate = tax_amount / subtotal_price

--- a/lib/offsite_payments/integrations/molpay.rb
+++ b/lib/offsite_payments/integrations/molpay.rb
@@ -64,7 +64,7 @@ module OffsitePayments #:nodoc:
           unless money > 0
             raise ArgumentError, "amount must be greater than $0.00."
           end
-          add_field mappings[:amount], sprintf("%.2f", money.to_f)
+          add_field mappings[:amount], sprintf("%.2f", money.to_d)
         end
 
         def currency=(cur)

--- a/lib/offsite_payments/integrations/nochex.rb
+++ b/lib/offsite_payments/integrations/nochex.rb
@@ -98,7 +98,7 @@ module OffsitePayments #:nodoc:
           raise ArgumentError, "amount must be a Money object or an integer" if money.is_a?(String)
           raise ActionViewHelperError, "amount must be greater than $0.00" if cents.to_i <= 0
 
-          add_field mappings[:amount], sprintf("%.2f", cents.to_f/100)
+          add_field mappings[:amount], sprintf("%.2f", cents.to_d/100)
         end
 
         # Optional Parameters
@@ -180,7 +180,7 @@ module OffsitePayments #:nodoc:
 
         # the money amount we received in X.2 decimal.
         def gross
-          sprintf("%.2f", params['amount'].to_f)
+          sprintf("%.2f", params['amount'].to_d)
         end
 
         # Was this a test transaction?

--- a/lib/offsite_payments/integrations/payu_in.rb
+++ b/lib/offsite_payments/integrations/payu_in.rb
@@ -241,7 +241,7 @@ module OffsitePayments #:nodoc:
 
         private
         def parse_and_round_gross_amount(amount)
-          rounded_amount = (amount.to_f * 100.0).round
+          rounded_amount = (amount.to_d * 100.0).round
           sprintf("%.2f", rounded_amount / 100.00)
         end
       end

--- a/lib/offsite_payments/integrations/pxpay.rb
+++ b/lib/offsite_payments/integrations/pxpay.rb
@@ -30,7 +30,7 @@ module OffsitePayments #:nodoc:
             'TxnData1'          => options[:custom1],
             'TxnData2'          => options[:custom2],
             'TxnData3'          => options[:custom3],
-            'AmountInput'       => "%.2f" % options[:amount].to_f.round(2),
+            'AmountInput'       => "%.2f" % options[:amount].to_d.round(2),
             'EnableAddBillCard' => '0',
             'TxnType'           => 'Purchase',
             'UrlSuccess'        => options[:return_url],

--- a/lib/offsite_payments/integrations/valitor.rb
+++ b/lib/offsite_payments/integrations/valitor.rb
@@ -96,7 +96,7 @@ module OffsitePayments #:nodoc:
         end
 
         def format_amount(amount, currency)
-          OffsitePayments::CURRENCIES_WITHOUT_FRACTIONS.include?(currency) ? amount.to_f.round : sprintf("%.2f", amount)
+          OffsitePayments::CURRENCIES_WITHOUT_FRACTIONS.include?(currency) ? amount.to_d.round : sprintf("%.2f", amount)
         end
       end
 

--- a/lib/offsite_payments/notification.rb
+++ b/lib/offsite_payments/notification.rb
@@ -27,7 +27,7 @@ module OffsitePayments #:nodoc:
     end
 
     def gross_cents
-      (gross.to_f * 100.0).round
+      (gross.to_d * 100.0).round
     end
 
     # This combines the gross and currency and returns a proper Money object.


### PR DESCRIPTION
WIP -- Thinking through this

## What
Replace all `to_f` calls with `to_d`

## Why
floats can't be trusted. They sometimes result in rounding errors.

## Look out for
`nil.to_f` returns 0 vs `nil.to_d` will raise.

also big decimals are slower when used in computation but faster then converting to a string
```
require "benchmark" 
require "bigdecimal" 

d = BigDecimal.new(3) 
f = Float(3)

time_decimal = Benchmark.measure{ (1..10000000).each { |i| d * d } } 
time_float = Benchmark.measure{ (1..10000000).each { |i| f * f } }
time_float_string = Benchmark.measure{ (1..10000000).each { |i| "%.2f" % ( f * f ) } }

puts time_decimal 
#=> 5.853376 seconds 
puts time_float 
#=> 0.530790 seconds
puts time_float_string
#=> 8.283518 seconds
```