### PR TITLE
Remove `rescue JSON::ParseError nil` pattern in BitPay integration

### DIFF
--- a/lib/offsite_payments/integrations/bit_pay.rb
+++ b/lib/offsite_payments/integrations/bit_pay.rb
@@ -89,7 +89,6 @@ module OffsitePayments #:nodoc:
 
         def item_id
           JSON.parse(params['posData'])['orderId']
-        rescue JSON::ParserError
         end
 
         def status
@@ -132,14 +131,12 @@ module OffsitePayments #:nodoc:
           retrieved_json = JSON.parse(@raw).tap { |j| j.delete('currentTime') }
 
           posted_json == retrieved_json
-        rescue JSON::ParserError
         end
 
         private
         def parse(body)
           @raw = body
           @params = JSON.parse(@raw)
-        rescue JSON::ParserError
         end
       end
 

--- a/test/unit/integrations/bit_pay/bit_pay_helper_test.rb
+++ b/test/unit/integrations/bit_pay/bit_pay_helper_test.rb
@@ -50,10 +50,4 @@ class BitPayHelperTest < Test::Unit::TestCase
 
     assert_equal '98kui1gJ7FocK41gUaBZxG', @helper.form_fields['id']
   end
-
-  def test_raises_when_invalid_json_returned
-    Net::HTTP.any_instance.expects(:request).returns(stub(:body => 'Invalid JSON'))
-
-    assert_raises(ActionViewHelperError) { @helper.form_fields['id'] }
-  end
 end

--- a/test/unit/integrations/bit_pay/bit_pay_notification_test.rb
+++ b/test/unit/integrations/bit_pay/bit_pay_notification_test.rb
@@ -17,20 +17,6 @@ class BitPayNotificationTest < Test::Unit::TestCase
     assert_equal 123, @bit_pay.item_id
   end
 
-  def test_invalid_data
-    hash = JSON.parse(http_raw_data)
-    @bit_pay = BitPay::Notification.new('{"invalid":json}')
-
-    assert @bit_pay.params.empty?
-  end
-
-  def test_item_id_invalid_json
-    hash = JSON.parse(http_raw_data)
-    @bit_pay = BitPay::Notification.new(hash.merge('posData' => 'Invalid JSON').to_json)
-
-    assert_nil @bit_pay.item_id
-  end
-
   def test_compositions
     assert_equal Money.from_amount(10.00, 'USD'), @bit_pay.amount
   end
@@ -42,11 +28,6 @@ class BitPayNotificationTest < Test::Unit::TestCase
 
   def test_acknowledgement_error
     Net::HTTP.any_instance.expects(:request).returns(stub(:body => '{"error":"Doesnt match"}'))
-    assert !@bit_pay.acknowledge
-  end
-
-  def test_acknowledgement_invalid_json
-    Net::HTTP.any_instance.expects(:request).returns(stub(:body => '{invalid json'))
     assert !@bit_pay.acknowledge
   end
 


### PR DESCRIPTION
Silently swallowing errors is an anti-pattern, we're unable to see if something's wrong and retry in that case.