### PR TITLE
Updates success link text string for Valitor integration

### DIFF
--- a/lib/offsite_payments/integrations/valitor.rb
+++ b/lib/offsite_payments/integrations/valitor.rb
@@ -26,7 +26,7 @@ module OffsitePayments #:nodoc:
       class Helper < OffsitePayments::Helper
         include ActiveUtils::RequiresParameters
 
-        DEFAULT_SUCCESS_TEXT = "The transaction has been completed."
+        DEFAULT_SUCCESS_TEXT = "Til baka í verslun."
 
         def initialize(order, account, options={})
           options[:currency] ||= 'ISK'


### PR DESCRIPTION
Addresses #242 
Changes it to an Icelandic string which translates to "Back to store."