### PR TITLE
realex_offsite: set hpp version

### DIFF
--- a/lib/offsite_payments/integrations/realex_offsite.rb
+++ b/lib/offsite_payments/integrations/realex_offsite.rb
@@ -120,6 +120,7 @@ module OffsitePayments #:nodoc:
           add_field 'X-CURRENCY', @currency
           add_field 'X-TEST', @test.to_s
           add_field 'ORDER_ID', "#{order}#{@timestamp.to_i}"
+          add_field 'HPP_VERSION', '2'
         end
 
         def form_fields

--- a/test/unit/integrations/realex_offsite/realex_offsite_helper_test.rb
+++ b/test/unit/integrations/realex_offsite/realex_offsite_helper_test.rb
@@ -29,6 +29,7 @@ class RealexOffsiteHelperTest < Test::Unit::TestCase
     assert_field 'AMOUNT', '999'
     assert_field 'CHECKOUT_ID', 'order-500'
     assert_field 'ORDER_ID', 'order-500' + @helper.fields["TIMESTAMP"]
+    assert_field 'HPP_VERSION', '2'
   end
 
   def test_default_helper_fields


### PR DESCRIPTION
If there is a a way to allow custom configuration beyond the [list of valid keys](https://github.com/activemerchant/offsite_payments/blob/master/lib/offsite_payments/helper.rb#L19), we'd prefer to allow this value to be overridable. Is that possible today without jumping through a bunch of hoops or going against current conventions?