### PR TITLE
update Skrill API URL

### DIFF
--- a/lib/offsite_payments/integrations/moneybookers.rb
+++ b/lib/offsite_payments/integrations/moneybookers.rb
@@ -2,7 +2,7 @@ module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Moneybookers
       mattr_accessor :production_url
-      self.production_url = 'https://www.moneybookers.com/app/payment.pl'
+      self.production_url = 'https://pay.skrill.com'
 
       def self.service_url
         self.production_url

--- a/test/unit/integrations/moneybookers/moneybookers_module_test.rb
+++ b/test/unit/integrations/moneybookers/moneybookers_module_test.rb
@@ -8,7 +8,7 @@ class MoneybookersModuleTest < Test::Unit::TestCase
   end
 
   def test_service_url
-    url = 'https://www.moneybookers.com/app/payment.pl'
+    url = 'https://pay.skrill.com'
     assert_equal url, Moneybookers.service_url
   end
 end


### PR DESCRIPTION
https://www.moneybookers.com/app/payment.pl is a legacy URL which will be discontinued on September 1th 2017.

The most recent documentation can be found on https://www.skrill.com/fileadmin/content/pdf/Skrill_Quick_Checkout_Guide.pdf