### PR TITLE
Fix PayTM checksum generation

### DIFF
--- a/lib/offsite_payments/integrations/paytm.rb
+++ b/lib/offsite_payments/integrations/paytm.rb
@@ -77,9 +77,12 @@ module OffsitePayments #:nodoc:
         end
 
         def encrypt_checksum
-          payload_items = CHECKSUM_FIELDS.reduce({}) do |items, field|
-            items[field] = @fields[field]
+          payload_items = {}
+
+          CHECKSUM_FIELDS.each do |field|
+            payload_items[field] = @fields[field]
           end
+
           Paytm.encrypt(Paytm.checksum(payload_items), @options[:credential2])
         end
 


### PR DESCRIPTION
With `reduce`, we need to return the `memo` from the block. In this case, we weren't, hence the resulting value of the assignation was used as the `memo` value forwarded to the next loop, generating exceptions.

A simple solution would have been to use `slice` on `@fields`, but we still need keys that could potentially be in `CHECKSUM_FIELDS` and not in `fields` to generate the proper signature.