### PR TITLE
Fix discount BigDecimal initialization in PayuIn#amount_ok?

### DIFF
--- a/lib/offsite_payments/integrations/payu_in.rb
+++ b/lib/offsite_payments/integrations/payu_in.rb
@@ -117,7 +117,7 @@ module OffsitePayments #:nodoc:
 
         # Order amount should be equal to gross - discount
         def amount_ok?( order_amount, order_discount = BigDecimal.new( '0.0' ) )
-          BigDecimal.new( original_gross ) == order_amount && BigDecimal.new( discount.to_s ) == order_discount
+          BigDecimal.new( original_gross ) == order_amount && discount.to_d == order_discount
         end
 
         # Status of transaction return from the PayU. List of possible values:

--- a/test/unit/integrations/citrus/citrus_return_test.rb
+++ b/test/unit/integrations/citrus/citrus_return_test.rb
@@ -44,7 +44,7 @@ class CitrusReturnTest < Test::Unit::TestCase
     assert_equal "Completed", notification.status
     assert_equal "CTX1309180549472058821", notification.transaction_id
     assert_equal "SUCCESS", notification.transaction_status
-    assert_equal Money.from_amount(BigDecimal.new(10), :inr), notification.amount
+    assert_equal Money.from_amount(BigDecimal.new(10), "inr"), notification.amount
     assert_equal "INR", notification.currency
     assert_equal true, notification.invoice_ok?('ORD427')
     assert_equal true, notification.amount_ok?(BigDecimal.new('10.00'))

--- a/test/unit/integrations/molpay/molpay_return_test.rb
+++ b/test/unit/integrations/molpay/molpay_return_test.rb
@@ -15,6 +15,7 @@ class MolpayReturnTest < Test::Unit::TestCase
   end
 
   def test_failed?
+    Molpay::Notification.any_instance.stubs(:ssl_post).returns('DECLINED')
     molpay = Molpay::Return.new('', :credential2 => @secret)
     refute molpay.success?
   end


### PR DESCRIPTION
The `PayuIn#amount_ok?` method initializes a BigDecimal with the discount as given in the params.

If the discount value is invalid as an argument for BigDecimal (e.g. '0.'), then the latest BigDecimal v1.3.2 (bundled by default in Ruby 2.4) raises an exception.

The behaviour of the current version of BigDecimal is to silently initialize any invalid arguments to a value of 0.00.

To support the new BigDecimal and preserve current behaviour, the method now uses `discount.to_d` to create a BigDecimal for purposes of zero coercion, instead of `BigDecimal.new(discount.to_s)`.