### PR TITLE
[WorldPay] Use multiple address fields

### DIFF
--- a/lib/offsite_payments/integrations/world_pay.rb
+++ b/lib/offsite_payments/integrations/world_pay.rb
@@ -34,8 +34,13 @@ module OffsitePayments #:nodoc:
         mapping :customer, :email => 'email',
                            :phone => 'tel'
 
-        mapping :billing_address, :zip => 'postcode',
-                                  :country  => 'country'
+        mapping :billing_address,
+          :address1 => 'address1',
+          :address2 => 'address2',
+          :city => 'town',
+          :state => 'region',
+          :zip => 'postcode',
+          :country  => 'country'
 
         mapping :description, 'desc'
         mapping :notify_url, 'MC_callback'
@@ -60,16 +65,6 @@ module OffsitePayments #:nodoc:
           elsif OffsitePayments.mode == :always_fail
             add_field('testMode', '101')
           end
-        end
-
-        # WorldPay only supports a single address field so we
-        # have to concat together - lines are separated using &#10;
-        def billing_address(params={})
-          add_field(mappings[:billing_address][:zip], params[:zip])
-          add_field(mappings[:billing_address][:country], lookup_country_code(params[:country]))
-
-          address = [params[:address1], params[:address2], params[:city], params[:state]].compact
-          add_field('address', address.join('&#10;'))
         end
 
         # WorldPay only supports a single name field so we have to concat

--- a/test/unit/integrations/world_pay/world_pay_helper_test.rb
+++ b/test/unit/integrations/world_pay/world_pay_helper_test.rb
@@ -33,7 +33,10 @@ class WorldPayHelperTest < Test::Unit::TestCase
                             :zip => 'CV1 1AA',
                             :country  => 'GB'
 
-    assert_field 'address', '1 Nowhere Close&#10;Electric Wharf&#10;Coventry&#10;Warwickshire'
+    assert_field 'address1', '1 Nowhere Close'
+    assert_field 'address2', 'Electric Wharf'
+    assert_field 'town', 'Coventry'
+    assert_field 'region', 'Warwickshire'
     assert_field 'postcode', 'CV1 1AA'
     assert_field 'country', 'GB'
   end
@@ -44,7 +47,8 @@ class WorldPayHelperTest < Test::Unit::TestCase
                             :zip => '10000',
                             :country  => 'DE'
 
-    assert_field 'address', 'Teststr. 1&#10;Berlin'
+    assert_field 'address1', 'Teststr. 1'
+    assert_field 'town', 'Berlin'
     assert_field 'postcode', '10000'
     assert_field 'country', 'DE'
   end


### PR DESCRIPTION
The current mapping for WorldPay concatenates `address1`, `address2`, `city` & `state` into one field "address".

That caused address to be displayed weirdly on WorldPay's end.

WorldPay does support sending address fields separately. [WorldPay Specification](http://support.worldpay.com/support/kb/bg/htmlredirect/htmlredirect.htm?_ga=2.98809374.1679648923.1513589946-2013789715.1513589946#rhtml/HTML_Redirect_parameters.htm%3FTocPath%3D_____8)

This PR removes the need to concatenate address data.

  