### PR TITLE
Paytm::Notification#checksum_ok? should always return a boolean predicate

### DIFF
--- a/lib/offsite_payments/integrations/paytm.rb
+++ b/lib/offsite_payments/integrations/paytm.rb
@@ -207,6 +207,8 @@ module OffsitePayments #:nodoc:
             @message = 'Return checksum not matching the data provided'
             false
           end
+        rescue
+          return false
         end
 
         private

--- a/test/unit/integrations/paytm/paytm_notification_test.rb
+++ b/test/unit/integrations/paytm/paytm_notification_test.rb
@@ -31,6 +31,18 @@ class PaytmNotificationTest < Test::Unit::TestCase
     assert @paytm.acknowledge
   end
 
+  def test_checksum_ok_returns_false_when_checksum_is_nil
+    @paytm = Paytm::Notification.new(
+      http_raw_data.gsub('&CHECKSUMHASH=M9E4OLugj4L3TLLiof2BSO03hhQQLMucnVgtYuHi4wIVLB20dCXS632PRw0dTmnAa58R0kEuh9%2bV3bfQs4F/SrlmsmV%2bhvhb3Nui1zlnh/o=', ''),
+      credential1: 'WorldP64425807474247',
+      credential2: 'kbzk1DSbJiV_O3p5',
+      credential3: 'Retail',
+      credential4: 'worldpressplg'
+    )
+
+    assert_equal false, @paytm.checksum_ok?
+  end
+
   private
 
   def http_raw_data


### PR DESCRIPTION
Sometimes the Paytm notification get initialized with params that are lacking
the `CHECKSUMHASH` key. This makes #checksum_ok? blow up and raise excepions
on our side.