### PR TITLE
Paytm to accepts phone numbers as customer identifier

### DIFF
--- a/lib/offsite_payments/integrations/paytm.rb
+++ b/lib/offsite_payments/integrations/paytm.rb
@@ -51,9 +51,6 @@ module OffsitePayments #:nodoc:
         mapping :account, 'MID'
         mapping :order, 'MERC_UNQ_REF'
 
-        mapping :customer, :email => 'CUST_ID'
-
-
         mapping :credential3, 'INDUSTRY_TYPE_ID'
         mapping :credential4, 'WEBSITE'
         mapping :channel_id, 'CHANNEL_ID'
@@ -69,6 +66,17 @@ module OffsitePayments #:nodoc:
           add_field 'ORDER_ID', "#{order}-#{@timestamp.to_i}"
 
           self.pg = 'CC'
+        end
+
+        def customer(options = {})
+          customer_id =
+            if options[:email].present?
+              sanitize_field(options[:email])
+            else
+              sanitize_field(options[:phone])
+            end
+
+          add_field('CUST_ID', customer_id)
         end
 
         def form_fields
@@ -88,8 +96,12 @@ module OffsitePayments #:nodoc:
 
         def sanitize_fields
           %w(email phone).each do |field|
-            @fields[field].gsub!(/[^a-zA-Z0-9\-_@\/\s.]/, '') if @fields[field]
+            sanitize_field(@fields[field])
           end
+        end
+
+        def sanitize_field(field)
+          field.gsub!(/[^a-zA-Z0-9\-_@\/\s.]/, '') if field
         end
       end
 


### PR DESCRIPTION
The current implementation assumes an email should always be used for customer identifier. That isn't always the case, as we often only receive a phone number. This change makes sure we fallback to the phone number when email isn't provided.

We also need to sanitize identifiers prior to sending them to PayTM, the same way we sanitize them before generating the checksum. Characters such as `+` (present in phone numbers) won't pass the validation on their side and will fail the transaction.