### PR TITLE
Ensure values are always sanitized

### DIFF
--- a/lib/offsite_payments/integrations/paytm.rb
+++ b/lib/offsite_payments/integrations/paytm.rb
@@ -96,12 +96,12 @@ module OffsitePayments #:nodoc:
 
         def sanitize_fields
           %w(email phone).each do |field|
-            sanitize_field(@fields[field])
+            @fields[field] = sanitize_field(@fields[field])
           end
         end
 
         def sanitize_field(field)
-          field.gsub!(/[^a-zA-Z0-9\-_@\/\s.]/, '') if field
+          field.gsub(/[^a-zA-Z0-9\-_@\/\s.]/, '') if field
         end
       end
 


### PR DESCRIPTION
In `customer`, we do;

```
           customer_id =
             if options[:email].present?
               sanitize_field(options[:email])
             else
               sanitize_field(options[:phone])
             end
```

It calls `sanitize_field`, which in its current form, calls `gsub!`. Since `gsub!` modifies the content in place, it doesn't return any value, hence `customer_id` is always `nil`.

```
irb(main):006:0> "abc".gsub!(/^a-z/, '')
=> nil
irb(main):007:0> "abc".gsub(/^a-z/, '')
=> "abc"
```

This patch modifies the behaviour of `sanitize_field` to return the new sanitized value.

🎩 'ed with both flows, phone and email.