### PR TITLE
[BitPay] Removes rescue during invoice creation

### DIFF
--- a/lib/offsite_payments/integrations/bit_pay.rb
+++ b/lib/offsite_payments/integrations/bit_pay.rb
@@ -74,7 +74,6 @@ module OffsitePayments #:nodoc:
 
           response = http.request(request)
           JSON.parse(response.body)
-        rescue JSON::ParserError
         end
       end
 


### PR DESCRIPTION
Removes `rescue` from `BitPay#create_invoice`. When an error occurs it should bubble up instead of being swallowed.