### PR TITLE
Bumps version to 2.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Offsite Payments CHANGELOG
 
+### Version 2.6.8 (Mar 22, 2018)
+- Ensure values are always sanitized [christianblais] #281
+- Updates exception handling for BitPay [joshnuss] #282
+
 ### Version 2.6.7 (Mar 7, 2018)
 - Add GET retries for Mollie offsites [Girardvjonathan] #279
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    offsite_payments (2.6.7)
+    offsite_payments (2.6.8)
       actionpack (>= 3.2.20, < 6.0)
       active_utils (~> 3.3.0)
       activesupport (>= 3.2.14)
@@ -36,7 +36,7 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    active_utils (3.3.10)
+    active_utils (3.3.11)
       activesupport (>= 3.2, < 6.0)
       i18n
     activejob (5.1.5)

--- a/lib/offsite_payments/version.rb
+++ b/lib/offsite_payments/version.rb
@@ -1,3 +1,3 @@
 module OffsitePayments
-  VERSION = "2.6.7"
+  VERSION = "2.6.8"
 end


### PR DESCRIPTION
Bump version to 2.6.8, it includes:

- Ensure values are always sanitized [christianblais] #281
- Updates exception handling for BitPay [joshnuss] #282