### PR TITLE
Update Loofah gem to 2.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ GEM
       concurrent-ruby (~> 1.0)
     launchy (2.4.3)
       addressable (~> 2.3)
-    loofah (2.2.0)
+    loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)


### PR DESCRIPTION
Fixes CVE-2018-8048 - https://github.com/flavorjones/loofah/issues/144