### PR TITLE
Ignore .lock from gemfiles folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .yardoc
 pkg
 *.gem
+gemfiles/Gemfile.*.lock


### PR DESCRIPTION
This basically ignores all .lock files for specific gemfiles in
`gemfiles/` folder