### PR TITLE
Update configs to match correct money gem name from Shopify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ matrix:
   include:
     - rvm: 2.3.3
       gemfile: gemfiles/Gemfile.shopify
+    - rvm: 2.4.0
+      gemfile: gemfiles/Gemfile.shopify
 
 before_install:
   - gem update bundler

--- a/gemfiles/Gemfile.shopify
+++ b/gemfiles/Gemfile.shopify
@@ -10,4 +10,4 @@ group :remote_test do
 end
 
 gem 'actionpack', '~> 5.0.0'
-gem 'money', git: 'https://github.com/Shopify/money.git'
+gem 'shopify-money', require: 'money', git: 'https://github.com/Shopify/money.git'


### PR DESCRIPTION
Also, include ruby 2.4.0 into shopify gemfile pipeline in Travis