### PR TITLE
Remove Money gem as dependency into gemspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ sudo: false
 cache: bundler
 
 rvm:
-- 2.4.0
-- 2.3.3
-- 2.2.3
+- 2.4
+- 2.3
+- 2.2
 - 2.1
 
 gemfile:
@@ -25,16 +25,18 @@ matrix:
       gemfile: gemfiles/Gemfile.rails51
     - rvm: 2.1
       gemfile: gemfiles/Gemfile.rails52
-    - rvm: 2.4.0
+    - rvm: 2.4
       gemfile: gemfiles/Gemfile.rails32
-    - rvm: 2.4.0
+    - rvm: 2.4
       gemfile: gemfiles/Gemfile.rails40
-    - rvm: 2.4.0
+    - rvm: 2.4
       gemfile: gemfiles/Gemfile.rails41
-    - rvm: 2.4.0
+    - rvm: 2.4
       gemfile: gemfiles/Gemfile.rails42
   include:
-    - rvm: 2.3.3
+    - rvm: 2.3
+      gemfile: gemfiles/Gemfile.shopify
+    - rvm: 2.4
       gemfile: gemfiles/Gemfile.shopify
 
 before_install:

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,5 @@ group :remote_test do
   gem 'launchy'
   gem 'mongrel', '1.2.0.pre2', :platforms => :ruby
 end
+
+gem 'money', '~> 6.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,6 @@ PATH
       activesupport (>= 3.2.14)
       builder (>= 2.1.2, < 4.0.0)
       i18n (>= 0.6.6)
-      money (< 7.0.0)
       nokogiri (~> 1.6)
 
 GEM
@@ -165,6 +164,7 @@ DEPENDENCIES
   launchy
   mechanize
   mocha (~> 1.0)
+  money (~> 6.8)
   mongrel (= 1.2.0.pre2)
   offsite_payments!
   rails (>= 3.2.14)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The addition of your gateway to offsite_payments does not guarantee placement wi
 4. Your most recent Certificate of PCI Compliance
 5. Reason that the [Universal API](https://github.com/activemerchant/offsite_payments/blob/master/lib/offsite_payments/integrations/universal.rb)* cannot be used for your integration.
 
-*The Universal API defines a standard set of requests and callbacks that can be used to integrate with Shopify. A sample app and documentation are hosted [here](https://github.com/Shopify/offsite-gateway-sim). The Universal API should be used for all integrations in which placement within Shopify is the desired outcome. 
+*The Universal API defines a standard set of requests and callbacks that can be used to integrate with Shopify. A sample app and documentation are hosted [here](https://github.com/Shopify/offsite-gateway-sim). The Universal API should be used for all integrations in which placement within Shopify is the desired outcome.
 
 ## Installation
 
@@ -36,6 +36,19 @@ Installation from RubyGems:
 Or, if you're using Bundler, just add the following to your Gemfile:
 
     gem 'offsite_payments'
+
+### Money gem dependency
+
+At the moment, `offsite_payments` gem depends on `Money` object, which was previously included by default. Since Shopify
+released their own `shopify-money` gem. Because `offsite_payments` does not impose which one of those gems should be
+included into your gem file, as long as one of them is included.
+
+
+- For [ruby money gem]() add `gem 'money'` to your `Gemfile`;
+- For [Shopify money gem]() add `gem 'shopify-money', require: 'money'` in your `Gemfile`.
+
+It's important to note that either of those Money gems would need to be added to your `Gemfile` before the `offsite_payments`
+one.
 
 [API documentation](http://www.rubydoc.info/github/activemerchant/offsite_payments/master).
 

--- a/gemfiles/Gemfile.rails32
+++ b/gemfiles/Gemfile.rails32
@@ -10,3 +10,4 @@ group :remote_test do
 end
 
 gem 'actionpack', '~> 3.2.0'
+gem 'money', '~> 6.8'

--- a/gemfiles/Gemfile.rails40
+++ b/gemfiles/Gemfile.rails40
@@ -10,3 +10,4 @@ group :remote_test do
 end
 
 gem 'actionpack', '~> 4.0.0'
+gem 'money', '~> 6.8'

--- a/gemfiles/Gemfile.rails41
+++ b/gemfiles/Gemfile.rails41
@@ -10,3 +10,4 @@ group :remote_test do
 end
 
 gem 'actionpack', '~> 4.1.0'
+gem 'money', '~> 6.8'

--- a/gemfiles/Gemfile.rails42
+++ b/gemfiles/Gemfile.rails42
@@ -10,3 +10,4 @@ group :remote_test do
 end
 
 gem 'actionpack', '~> 4.2.0'
+gem 'money', '~> 6.8'

--- a/gemfiles/Gemfile.rails50
+++ b/gemfiles/Gemfile.rails50
@@ -10,3 +10,4 @@ group :remote_test do
 end
 
 gem 'actionpack', '~> 5.0.0'
+gem 'money', '~> 6.8'

--- a/gemfiles/Gemfile.rails51
+++ b/gemfiles/Gemfile.rails51
@@ -10,3 +10,4 @@ group :remote_test do
 end
 
 gem 'actionpack', '~> 5.1.0'
+gem 'money', '~> 6.8'

--- a/gemfiles/Gemfile.rails52
+++ b/gemfiles/Gemfile.rails52
@@ -10,3 +10,4 @@ group :remote_test do
 end
 
 gem 'actionpack', '~> 5.2.0'
+gem 'money', '~> 6.8'

--- a/gemfiles/Gemfile.shopify
+++ b/gemfiles/Gemfile.shopify
@@ -10,4 +10,4 @@ group :remote_test do
 end
 
 gem 'actionpack', '~> 5.0.0'
-gem 'money', git: 'https://github.com/Shopify/money.git'
+gem 'shopify-money',  require: 'money'

--- a/lib/offsite_payments.rb
+++ b/lib/offsite_payments.rb
@@ -1,3 +1,6 @@
+fail %q{
+  Money is required for offsite_payments to work, please refer to https://github.com/activemerchant/offsite_payments#money-gem-dependency
+} unless defined?(Money)
 require 'securerandom'
 require 'cgi'
 require "timeout"

--- a/offsite_payments.gemspec
+++ b/offsite_payments.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency('activesupport', '>= 3.2.14')
   s.add_dependency('i18n', '>= 0.6.6')
-  s.add_dependency('money', '< 7.0.0')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('active_utils', '~> 3.3.0')
   s.add_dependency('nokogiri', "~> 1.6")

--- a/offsite_payments.gemspec
+++ b/offsite_payments.gemspec
@@ -22,6 +22,22 @@ Gem::Specification.new do |s|
   s.files = Dir['CHANGELOG', 'README.md', 'MIT-LICENSE', 'lib/**/*']
   s.require_path = 'lib'
 
+  unless defined?(Money)
+    s.post_install_message = %q{
+    In order to use `offsite_payments` gem, you need to either install or add to your Gemfile
+    one of the two options for Money gem:
+      - `gem 'money'`
+      - `gem 'shopify-money', require: 'money'`
+
+    Regardless of which gem you choose, please add them *before* `offsite_payments`.
+    For more info, go to https://github.com/activemerchant/offsite_payments#money-gem-dependency
+
+    It's also important to note that all Money object usage inside `offsite_payments` is being
+    deprecated. We encourage you to use your own Money object inside your app instead of relying
+    on `offsite_payments` doing it for you, e.g. `Money.from_amount(notification.gross)`
+    }
+  end
+
   s.add_dependency('activesupport', '>= 3.2.14')
   s.add_dependency('i18n', '>= 0.6.6')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')


### PR DESCRIPTION
Since Shopify is releasing the shopify-money gem to public, this won't
be included by default, but still required.

Post install message
```
 🏈 in testing at (master) $ gem install /Users/filipecosta/src/github.com/filipebarcos/offsite_payments/offsite_payments-2.6.8.gem
    In order to use `offsite_payments` gem, you need to either install or add to your Gemfile
    one of the two options for Money gem:
      - `gem 'money'`
      - `gem 'shopify-money', require: 'money'`
    Regardless of which gem you choose, please add them *before* `offsite_payments`.
    For more info, go to https://github.com/filipebarcos/offsite_payments#money-gem-dependency
Successfully installed offsite_payments-2.6.8
1 gem installed
```

`fail` looks like this:
```
 🏈 in testing at (master) $ irb
>> require 'offsite_payments'
Traceback (most recent call last):
        6: from /opt/rubies/2.5.0/bin/irb:11:in `<main>'
        5: from (irb):1
        4: from /opt/rubies/2.5.0/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:39:in `require'
        3: from /opt/rubies/2.5.0/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
        2: from /opt/rubies/2.5.0/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:135:in `require'
        1: from /Users/filipecosta/.gem/ruby/2.5.0/gems/offsite_payments-2.6.8/lib/offsite_payments.rb:1:in `<top (required)>'
RuntimeError (
  Money is required for offsite_payments to work, please refer to https://github.com/filipebarcos/offsite_payments#money-gem-dependency
)
```