### PR TITLE
"ubygems" has been removed from Ruby 2.5

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,14 +25,12 @@ task :test => 'test:units'
 namespace :test do
   Rake::TestTask.new(:units) do |t|
     t.pattern = 'test/unit/**/*_test.rb'
-    t.ruby_opts << '-rubygems'
     t.libs << 'test'
     t.verbose = true
   end
 
   Rake::TestTask.new(:remote) do |t|
     t.pattern = 'test/remote/**/*_test.rb'
-    t.ruby_opts << '-rubygems'
     t.libs << 'test'
     t.verbose = true
   end


### PR DESCRIPTION
Thus requiring it with the `-r` flag doesn't work. 
Similar to https://github.com/activemerchant/active_merchant/commit/b2423daee0b7d502d447f169204fd5b7bd57f2bf