### PR TITLE
remove test issuers

### DIFF
--- a/lib/offsite_payments/integrations/mollie_ideal.rb
+++ b/lib/offsite_payments/integrations/mollie_ideal.rb
@@ -18,18 +18,12 @@ module OffsitePayments #:nodoc:
         ["van Lanschot", "ideal_FVLBNL22"]
       ]
 
-      mattr_accessor :test_issuers
-      self.test_issuers = [
-        ["TBM Bank", "ideal_TESTNL99"]
-      ]
-
       def self.redirect_param_label
         "Select your bank"
       end
 
       def self.redirect_param_options(options = {})
-        return test_issuers if options[:credential1].blank?
-        options[:credential1].start_with?('live_') ? live_issuers : test_issuers
+        live_issuers
       end
 
       def self.retrieve_issuers(token)

--- a/test/remote/remote_mollie_ideal_test.rb
+++ b/test/remote/remote_mollie_ideal_test.rb
@@ -11,18 +11,13 @@ class RemoteMollieIdealTest < Test::Unit::TestCase
     assert_raises(ActiveUtils::ResponseError) { MollieIdeal.retrieve_issuers('bad_api_key') }
   end
 
-  def test_retrieve_issuers
-    issuers = MollieIdeal.retrieve_issuers(@api_key)
-    assert_equal [["TBM Bank", "ideal_TESTNL99"]], issuers
-  end
-
   def test_create_payment_and_check_status
     create_response = MollieIdeal.create_payment(@api_key,
       :amount => BigDecimal.new('123.45'),
       :description => 'My order description',
       :redirectUrl => 'https://example.com/return',
       :method => 'ideal',
-      :issuer => 'ideal_TESTNL99',
+      :issuer => MollieIdeal.live_issuers[0][1],
       :metadata => { :my_reference => 'unicorn' }
     )
 
@@ -31,6 +26,7 @@ class RemoteMollieIdealTest < Test::Unit::TestCase
     assert_equal 'My order description', create_response['description']
     assert_equal 'ideal', create_response['method']
     assert_equal 'unicorn', create_response['metadata']['my_reference']
+    assert_equal 'test', create_response['mode']
 
     assert_equal 'https://example.com/return', create_response['links']['redirectUrl']
     redirect_uri = URI.parse(create_response['links']['paymentUrl'])
@@ -38,6 +34,6 @@ class RemoteMollieIdealTest < Test::Unit::TestCase
     assert_equal 'www.mollie.com', redirect_uri.host
 
     status_response = MollieIdeal.check_payment_status(@api_key, create_response['id'])
-    assert_equal status_response, create_response
+    assert_equal status_response.except('expiryPeriod'), create_response.except('expiryPeriod')
   end
 end

--- a/test/unit/integrations/mollie_ideal/mollie_ideal_module_test.rb
+++ b/test/unit/integrations/mollie_ideal/mollie_ideal_module_test.rb
@@ -23,7 +23,7 @@ class MollieIdealModuleTest < Test::Unit::TestCase
     OffsitePayments.stubs(:mode).returns(:development)
 
     assert MollieIdeal.requires_redirect_param?
-    assert_equal [["TBM Bank", "ideal_TESTNL99"]], MollieIdeal.redirect_param_options(:credential1 => "test_blah")
+    assert MollieIdeal.redirect_param_options(:credential1 => "test_blah").include?(["Rabobank", "ideal_RABONL2U"])
 
     live_issuers = MollieIdeal.redirect_param_options(:credential1 => "live_blah")
     assert !live_issuers.include?(["TBM Bank", "ideal_TESTNL99"])


### PR DESCRIPTION
# Why

> We have removed the test issuers. For iDEAL, the issuers should be identical between live and test mode. So, what you'd previously send for live mode, can now be sent for all modes. This is reflected in our issuers API but I'm not sure you guys are using that. -- Mollie

closes https://github.com/activemerchant/offsite_payments/issues/293
closes https://github.com/Shopify/shopify/issues/155669

# What

Removed test issuers, in favour of a test mode with a live issuer. Remote test api key in fixtures is no longer valid, I've tested with my own key and tests pass.