### PR TITLE
[Mollie iDEAL] Remove requirement for query string parameters

### DIFF
--- a/lib/offsite_payments/integrations/mollie.rb
+++ b/lib/offsite_payments/integrations/mollie.rb
@@ -30,6 +30,35 @@ module OffsitePayments #:nodoc:
         end
       end
 
+      class Helper < OffsitePayments::Helper
+        def credential_based_url
+          response = request_redirect
+          @transaction_id = response['id']
+
+          uri = URI.parse(response['links']['paymentUrl'])
+          set_form_fields_for_redirect(uri)
+          uri.query = ''
+          uri.to_s.sub(/\?\z/, '')
+        end
+
+        def form_method
+          "GET"
+        end
+
+        private
+
+        def set_form_fields_for_redirect(uri)
+          return unless uri.query
+
+          CGI.parse(uri.query).each do |key, value|
+            if value.is_a?(Array) && value.length == 1
+              add_field(key, value.first)
+            else
+              add_field(key, value)
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/lib/offsite_payments/integrations/mollie_ideal.rb
+++ b/lib/offsite_payments/integrations/mollie_ideal.rb
@@ -99,6 +99,8 @@ module OffsitePayments #:nodoc:
         end
 
         def set_form_fields_for_redirect(uri)
+          return unless uri.query
+
           CGI.parse(uri.query).each do |key, value|
             if value.is_a?(Array) && value.length == 1
               add_field(key, value.first)

--- a/lib/offsite_payments/integrations/mollie_ideal.rb
+++ b/lib/offsite_payments/integrations/mollie_ideal.rb
@@ -61,7 +61,7 @@ module OffsitePayments #:nodoc:
         true
       end
 
-      class Helper < OffsitePayments::Helper
+      class Helper < Mollie::Helper
         attr_reader :transaction_id, :redirect_parameters, :token
 
         def initialize(order, account, options = {})
@@ -82,32 +82,6 @@ module OffsitePayments #:nodoc:
           raise ArgumentError, "The redirect_param option needs to be set to the bank_id the customer selected." if options[:redirect_param].blank?
           raise ArgumentError, "The return_url option needs to be set." if options[:return_url].blank?
           raise ArgumentError, "The description option needs to be set." if options[:description].blank?
-        end
-
-        def credential_based_url
-          response = request_redirect
-          @transaction_id = response['id']
-
-          uri = URI.parse(response['links']['paymentUrl'])
-          set_form_fields_for_redirect(uri)
-          uri.query = ''
-          uri.to_s.sub(/\?\z/, '')
-        end
-
-        def form_method
-          "GET"
-        end
-
-        def set_form_fields_for_redirect(uri)
-          return unless uri.query
-
-          CGI.parse(uri.query).each do |key, value|
-            if value.is_a?(Array) && value.length == 1
-              add_field(key, value.first)
-            else
-              add_field(key, value)
-            end
-          end
         end
 
         def request_redirect

--- a/lib/offsite_payments/integrations/mollie_mistercash.rb
+++ b/lib/offsite_payments/integrations/mollie_mistercash.rb
@@ -3,140 +3,130 @@ module OffsitePayments #:nodoc:
     module MollieMistercash
       include Mollie
 
-        RedirectError = Class.new(ActiveUtils::ActiveUtilsError)
+      RedirectError = Class.new(ActiveUtils::ActiveUtilsError)
 
-        def self.notification(post, options = {})
-          Notification.new(post, options)
+      def self.notification(post, options = {})
+        Notification.new(post, options)
+      end
+
+      def self.return(post, options = {})
+        Return.new(post, options)
+      end
+
+      def self.live?
+        OffsitePayments.mode == :production
+      end
+
+      def self.create_payment(token, params)
+        API.new(token).post_request('payments', params)
+      end
+
+      def self.check_payment_status(token, payment_id)
+        API.new(token).get_request("payments/#{payment_id}")
+      end
+
+      def self.requires_redirect_param?
+        false
+      end
+
+      class Helper < Mollie::Helper
+        attr_reader :transaction_id, :redirect_parameters, :token
+
+        def initialize(order, account, options = {})
+          @token = account
+          @redirect_parameters = {
+            :amount => options[:amount],
+            :description => options[:description],
+            :redirectUrl => options[:return_url],
+            :method => 'mistercash',
+            :metadata => { :order => order }
+          }
+
+          @redirect_parameters[:webhookUrl] = options[:notify_url] if options[:notify_url]
+
+          super
+
+          raise ArgumentError, "The return_url option needs to be set." if options[:return_url].blank?
+          raise ArgumentError, "The description option needs to be set." if options[:description].blank?
         end
 
-        def self.return(post, options = {})
-          Return.new(post, options)
-        end
-
-        def self.live?
-          OffsitePayments.mode == :production
-        end
-
-        def self.create_payment(token, params)
-          API.new(token).post_request('payments', params)
-        end
-
-        def self.check_payment_status(token, payment_id)
-          API.new(token).get_request("payments/#{payment_id}")
-        end
-
-        def self.requires_redirect_param?
-          false
-        end
-
-        class Helper < OffsitePayments::Helper
-          attr_reader :transaction_id, :redirect_parameters, :token
-
-            def initialize(order, account, options = {})
-              @token = account
-              @redirect_parameters = {
-                :amount => options[:amount],
-                :description => options[:description],
-                :redirectUrl => options[:return_url],
-                :method => 'mistercash',
-                :metadata => { :order => order }
-              }
-
-              @redirect_parameters[:webhookUrl] = options[:notify_url] if options[:notify_url]
-
-              super
-
-              raise ArgumentError, "The return_url option needs to be set." if options[:return_url].blank?
-              raise ArgumentError, "The description option needs to be set." if options[:description].blank?
-            end
-
-            def credential_based_url
-              response = request_redirect
-              uri = URI.parse(response['links']['paymentUrl'])
-              uri.to_s
-            end
-
-            def form_method
-              "GET"
-            end
-
-            def request_redirect
-              MollieMistercash.create_payment(token, redirect_parameters)
-            rescue ActiveUtils::ResponseError => e
-              case e.response.code
-              when '401', '403', '422'
-                error = JSON.parse(e.response.body)['error']['message']
-                raise ActionViewHelperError, error
-              when '503'
-                raise ActionViewHelperError, 'Service temporarily unavailable. Please try again.'
-              else
-                raise
-              end
-            end
-
-        end
-
-        class Notification < OffsitePayments::Notification
-          def initialize(post_arguments, options = {})
-            super
-
-            raise ArgumentError, "The transaction_id needs to be included in the query string." if transaction_id.nil?
-            raise ArgumentError, "The credential1 option needs to be set to the Mollie API key." if api_key.blank?
-          end
-
-          def complete?
-            true
-          end
-
-          def item_id
-            params['metadata']['order']
-          end
-
-          def transaction_id
-            params['id']
-          end
-
-          def api_key
-            @options[:credential1]
-          end
-
-          def currency
-            "EUR"
-          end
-
-          # the money amount we received in X.2 decimal.
-          def gross
-            @params['amount']
-          end
-
-          def gross_cents
-            (BigDecimal.new(@params['amount'], 2) * 100).to_i
-          end
-
-          def status
-            case @params['status']
-              when 'open';                 'Pending'
-              when 'paidout', 'paid';      'Completed'
-              else                         'Failed'
-            end
-          end
-
-          def test?
-            @params['mode'] == 'test'
-          end
-
-          def acknowledge(authcode = nil)
-            @params = check_payment_status(transaction_id)
-            true
-          end
-
-          def check_payment_status(transaction_id)
-            MollieMistercash.check_payment_status(@options[:credential1], transaction_id)
+        def request_redirect
+          MollieMistercash.create_payment(token, redirect_parameters)
+        rescue ActiveUtils::ResponseError => e
+          case e.response.code
+          when '401', '403', '422'
+            error = JSON.parse(e.response.body)['error']['message']
+            raise ActionViewHelperError, error
+          when '503'
+            raise ActionViewHelperError, 'Service temporarily unavailable. Please try again.'
+          else
+            raise
           end
         end
 
-        class Return < OffsitePayments::Return
+      end
+
+      class Notification < OffsitePayments::Notification
+        def initialize(post_arguments, options = {})
+          super
+
+          raise ArgumentError, "The transaction_id needs to be included in the query string." if transaction_id.nil?
+          raise ArgumentError, "The credential1 option needs to be set to the Mollie API key." if api_key.blank?
         end
+
+        def complete?
+          true
+        end
+
+        def item_id
+          params['metadata']['order']
+        end
+
+        def transaction_id
+          params['id']
+        end
+
+        def api_key
+          @options[:credential1]
+        end
+
+        def currency
+          "EUR"
+        end
+
+        # the money amount we received in X.2 decimal.
+        def gross
+          @params['amount']
+        end
+
+        def gross_cents
+          (BigDecimal.new(@params['amount'], 2) * 100).to_i
+        end
+
+        def status
+          case @params['status']
+          when 'open';                 'Pending'
+          when 'paidout', 'paid';      'Completed'
+          else                         'Failed'
+          end
+        end
+
+        def test?
+          @params['mode'] == 'test'
+        end
+
+        def acknowledge(authcode = nil)
+          @params = check_payment_status(transaction_id)
+          true
+        end
+
+        def check_payment_status(transaction_id)
+          MollieMistercash.check_payment_status(@options[:credential1], transaction_id)
+        end
+      end
+
+      class Return < OffsitePayments::Return
+      end
 
     end
   end

--- a/test/unit/integrations/mollie_ideal/mollie_ideal_helper_test.rb
+++ b/test/unit/integrations/mollie_ideal/mollie_ideal_helper_test.rb
@@ -56,6 +56,18 @@ class MollieIdealHelperTest < Test::Unit::TestCase
     assert_raises(ArgumentError) { MollieIdeal::Helper.new('order-500','1234567', @required_options.merge(:description => nil)) }
   end
 
+  def test_without_query_params
+    @mock_api.expects(:post_request)
+      .with('payments', :amount => 500, :description => 'Order #111', :method => 'ideal', :issuer => 'ideal_TESTNL99', :redirectUrl => 'https://return.com', :metadata => {:order => 'order-500'})
+      .returns(RESPONSE_WITHOUT_PARAMS)
+
+    uri = @helper.credential_based_url
+
+    assert_equal 'tr_djsfilasX', @helper.transaction_id
+    assert_equal "https://www.mollie.nl/paymentscreen/ideal/testmode", uri
+    assert_equal 0, @helper.fields.length
+  end
+
   CREATE_PAYMENT_RESPONSE_JSON = JSON.parse(<<-JSON)
     {
       "id":"tr_djsfilasX",
@@ -71,6 +83,26 @@ class MollieIdealHelperTest < Test::Unit::TestCase
       "details":null,
       "links":{
         "paymentUrl":"https://www.mollie.nl/paymentscreen/ideal/testmode?transaction_id=20a5a25c2bce925b4fabefd0410927ca&bank_trxid=0148703115482464",
+        "redirectUrl":"https://example.com/return"
+      }
+    }
+  JSON
+
+  RESPONSE_WITHOUT_PARAMS = JSON.parse(<<-JSON)
+    {
+      "id":"tr_djsfilasX",
+      "mode":"test",
+      "createdDatetime":"2014-03-03T10:17:05.0Z",
+      "status":"open",
+      "amount":"500.00",
+      "description":"My order description",
+      "method":"ideal",
+      "metadata":{
+        "my_reference":"unicorn"
+      },
+      "details":null,
+      "links":{
+        "paymentUrl":"https://www.mollie.nl/paymentscreen/ideal/testmode",
         "redirectUrl":"https://example.com/return"
       }
     }

--- a/test/unit/integrations/mollie_mistercash/mollie_mistercash_helper_test.rb
+++ b/test/unit/integrations/mollie_mistercash/mollie_mistercash_helper_test.rb
@@ -30,6 +30,18 @@ class MollieMistercashHelperTest < Test::Unit::TestCase
     assert_equal nil, @helper.fields['bank_trxid']
   end
 
+  def test_credential_based_url_with_query_params
+    @mock_api.expects(:post_request)
+      .with('payments', amount: 500, description: 'Order #111', method: 'mistercash', redirectUrl: 'https://return.com', metadata: {order: 'order-500'})
+      .returns(RESPONSE_WITH_PARAMS_JSON)
+
+    uri = @helper.credential_based_url
+
+    assert_equal 'https://www.mollie.com/paymentscreen/mistercash/testmode/ca8195a3dc8d5cbf2f7b130654abe5a5', uri
+    assert_equal '20a5a25c2bce925b4fabefd0410927ca', @helper.fields['transaction_id']
+    assert_equal '0148703115482464', @helper.fields['bank_trxid']
+  end
+
   def test_credential_based_url_errors
     @mock_api.expects(:post_request)
       .with('payments', :amount => 500, :description => 'Order #111', :method => 'mistercash', :redirectUrl => 'https://return.com', :metadata => {:order => 'order-500'})
@@ -68,6 +80,26 @@ class MollieMistercashHelperTest < Test::Unit::TestCase
       "details":null,
       "links":{
         "paymentUrl":"https://www.mollie.com/paymentscreen/mistercash/testmode/ca8195a3dc8d5cbf2f7b130654abe5a5",
+        "redirectUrl":"https://example.com/return"
+      }
+    }
+  JSON
+
+  RESPONSE_WITH_PARAMS_JSON = JSON.parse(<<-JSON)
+    {
+      "id":"tr_djsfilasX",
+      "mode":"test",
+      "createdDatetime":"2014-03-03T10:17:05.0Z",
+      "status":"open",
+      "amount":"500.00",
+      "description":"My order description",
+      "method":"mistercash",
+      "metadata":{
+        "my_reference":"unicorn"
+      },
+      "details":null,
+      "links":{
+        "paymentUrl":"https://www.mollie.com/paymentscreen/mistercash/testmode/ca8195a3dc8d5cbf2f7b130654abe5a5?transaction_id=20a5a25c2bce925b4fabefd0410927ca&bank_trxid=0148703115482464",
         "redirectUrl":"https://example.com/return"
       }
     }


### PR DESCRIPTION
The code was expecting that the URLs always contained query strings, but that is no longer the case. This PR removes the dependency on query string parameters.

TODO:
- [x] Allow empty query string
- [x] Support hash marks
- [x] Add support for mistercash

Here are some examples of URLs we get from iDEAL:

- https://pay.mollie.nl/payment/start/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
- https://www.abnamro.nl/nl/ideal/identification.do?randomizedstring=xxxxxxxxxx&trxid=xxxxxxxxxxxxxx
- https://diensten.regiobank.nl/online/ideal/#/sign?sp=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&trxid=xxxxxxxxxxxxxxxx 
- https://bcr.girogate.be/bi/t2bc?tx=xxxxxxxxx&rs=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&cs=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
- https://www.mollie.com/payscreen/out/xxxxxxxxxx
- https://www.mollie.com/paymentscreen/testmode/?method=ideal&token=xxxxxx
- https://www.mollie.com/paymentscreen/testmode/?method=mistercash&token=xxxxxx