### PR TITLE
Add `TXNDATETIME` to the whitelist of params to use for checksum verification

### DIFF
--- a/lib/offsite_payments/integrations/paytm.rb
+++ b/lib/offsite_payments/integrations/paytm.rb
@@ -11,7 +11,7 @@ module OffsitePayments #:nodoc:
 
       # self.test_url = 'https://pguat.paytm.com/oltp-web/processTransaction'
       # self.production_url = 'https://secure.paytm.in/oltp-web/processTransaction'
-      
+
       self.test_url = 'https://securegw-stage.paytm.in/theia/processTransaction'
       self.production_url = 'https://securegw.paytm.in/theia/processTransaction'
 
@@ -109,7 +109,7 @@ module OffsitePayments #:nodoc:
       end
 
       class Notification < OffsitePayments::Notification
-        PAYTM_RESPONSE_PARAMS = %w(MID BANKTXNID TXNAMOUNT CURRENCY STATUS RESPCODE RESPMSG TXNDATE GATEWAYNAME BANKNAME PAYMENTMODE PROMO_CAMP_ID PROMO_STATUS PROMO_RESPCODE ORDERID TXNID REFUNDAMOUNT REFID MERC_UNQ_REF CUSTID).freeze
+        PAYTM_RESPONSE_PARAMS = %w(MID BANKTXNID TXNAMOUNT CURRENCY STATUS RESPCODE RESPMSG TXNDATE GATEWAYNAME BANKNAME PAYMENTMODE PROMO_CAMP_ID PROMO_STATUS PROMO_RESPCODE ORDERID TXNID REFUNDAMOUNT REFID MERC_UNQ_REF CUSTID TXNDATETIME).freeze
 
         def initialize(post, options = {})
           super

--- a/test/unit/integrations/paytm/paytm_notification_test.rb
+++ b/test/unit/integrations/paytm/paytm_notification_test.rb
@@ -4,6 +4,7 @@ class PaytmNotificationTest < Test::Unit::TestCase
   include OffsitePayments::Integrations
 
   def setup
+    @checksum = "2TbZn8eQ5JP37cbnJGehTLMlkYhqZLxEUh3drQPn8SX3W44Ou3noDpY7CN0wBe1PIxopTzBvQRAsCtmIPzZtikp0dPj7DleHRG3olIiAvKA="
     @paytm = Paytm::Notification.new(http_raw_data, credential1: 'WorldP64425807474247', credential2: 'kbzk1DSbJiV_O3p5', credential3: 'Retail', credential4: 'worldpressplg')
   end
 
@@ -19,7 +20,7 @@ class PaytmNotificationTest < Test::Unit::TestCase
     assert_equal 'CC', @paytm.type
     assert_equal '100PT012', @paytm.invoice
     assert_equal 'WorldP64425807474247', @paytm.account
-    assert_equal 'M9E4OLugj4L3TLLiof2BSO03hhQQLMucnVgtYuHi4wIVLB20dCXS632PRw0dTmnAa58R0kEuh9+V3bfQs4F/SrlmsmV+hvhb3Nui1zlnh/o=', @paytm.checksum
+    assert_equal @checksum, @paytm.checksum
     assert_equal true, @paytm.checksum_ok?
   end
 
@@ -33,7 +34,7 @@ class PaytmNotificationTest < Test::Unit::TestCase
 
   def test_checksum_ok_returns_false_when_checksum_is_nil
     @paytm = Paytm::Notification.new(
-      http_raw_data.gsub('&CHECKSUMHASH=M9E4OLugj4L3TLLiof2BSO03hhQQLMucnVgtYuHi4wIVLB20dCXS632PRw0dTmnAa58R0kEuh9%2bV3bfQs4F/SrlmsmV%2bhvhb3Nui1zlnh/o=', ''),
+      http_raw_data.gsub("&CHECKSUMHASH=#{@checksum}", ''),
       credential1: 'WorldP64425807474247',
       credential2: 'kbzk1DSbJiV_O3p5',
       credential3: 'Retail',
@@ -46,6 +47,6 @@ class PaytmNotificationTest < Test::Unit::TestCase
   private
 
   def http_raw_data
-    'MID=WorldP64425807474247&ORDERID=100PT012&TXNAMOUNT=10&CURRENCY=INR&TXNID=494157&BANKTXNID=201512236592678&STATUS=TXN_SUCCESS&RESPCODE=01&RESPMSG=Txn Successful&TXNDATE=2015-12-23 16:06:22.0&GATEWAYNAME=ICICI&BANKNAME=ICICI&PAYMENTMODE=CC&MERC_UNQ_REF=100PT012&CHECKSUMHASH=M9E4OLugj4L3TLLiof2BSO03hhQQLMucnVgtYuHi4wIVLB20dCXS632PRw0dTmnAa58R0kEuh9%2bV3bfQs4F/SrlmsmV%2bhvhb3Nui1zlnh/o='
+    "MID=WorldP64425807474247&ORDERID=100PT012&TXNAMOUNT=10&CURRENCY=INR&TXNID=494157&BANKTXNID=201512236592678&STATUS=TXN_SUCCESS&RESPCODE=01&RESPMSG=Txn Successful&TXNDATE=2015-12-23 16:06:22.0&GATEWAYNAME=ICICI&BANKNAME=ICICI&PAYMENTMODE=CC&MERC_UNQ_REF=100PT012&TXNDATETIME=2018-12-04 22:08:45.0&CHECKSUMHASH=#{@checksum}"
   end
 end


### PR DESCRIPTION
Paytm notifications were no longer working since they added a new parameter
`TXNDATETIME` to their notification and checksum generation on their backend.

With this commit we aim to fix the checksum verification so it macthes how it
is done in Paytm's backend.