### PR TITLE
Live and Test against Rails edge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,23 @@ sudo: false
 cache: bundler
 
 rvm:
+- 2.5
 - 2.4
 - 2.3
 - 2.2
 
 gemfile:
 - gemfiles/Gemfile.rails50
-- gemfiles/Gemfile.rails51
+- gemfiles/Gemfile.latest-release
+- gemfiles/Gemfile.shopify
 
 matrix:
+  exclude:
+    - rvm: 2.2
+      gemfile: gemfiles/Gemfile.shopify
   include:
-    - rvm: 2.3
-      gemfile: gemfiles/Gemfile.shopify
-    - rvm: 2.4
-      gemfile: gemfiles/Gemfile.shopify
+    - rvm: 2.5
+      gemfile: gemfiles/Gemfile.rails-edge
 
 before_install:
   - gem update bundler

--- a/gemfiles/Gemfile.latest-release
+++ b/gemfiles/Gemfile.latest-release
@@ -9,5 +9,5 @@ group :remote_test do
   gem 'mongrel', '1.2.0.pre2', :platforms => :ruby
 end
 
-gem 'actionpack', '~> 5.1.0'
+gem 'actionpack'
 gem 'money', '~> 6.8'

--- a/gemfiles/Gemfile.rails-edge
+++ b/gemfiles/Gemfile.rails-edge
@@ -9,5 +9,5 @@ group :remote_test do
   gem 'mongrel', '1.2.0.pre2', :platforms => :ruby
 end
 
-gem 'actionpack', '~> 5.2.0'
+gem 'actionpack', github: 'rails/rails'
 gem 'money', '~> 6.8'

--- a/offsite_payments.gemspec
+++ b/offsite_payments.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('active_utils', '~> 3.3.0')
   s.add_dependency('nokogiri', "~> 1.6")
-  s.add_dependency('actionpack', '>= 3.2.20', '< 6.0')
+  s.add_dependency('actionpack', '>= 3.2.20')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('test-unit', '~> 3.0')


### PR DESCRIPTION
Live on the Rails edge. We can test the gem against latest Rails release (5.2) and Rails HEAD. Currently we have an upperbound constraint on ActionPack. We can remove this to be less conservative and not require it to be manually updated with future Rails releases. Since we will be testing against latest Rails automatically this should be safe as well.

resolves https://github.com/activemerchant/offsite_payments/issues/312

