### PR TITLE
[Bugfix] Update molpay.rb

### DIFF
--- a/lib/offsite_payments/integrations/molpay.rb
+++ b/lib/offsite_payments/integrations/molpay.rb
@@ -175,7 +175,7 @@ module OffsitePayments #:nodoc:
         
         def decode param
           return nil if param.nil?
-          URI.decode(param)
+          URI.decode_www_form_component(param)
         end
       end
 

--- a/lib/offsite_payments/integrations/molpay.rb
+++ b/lib/offsite_payments/integrations/molpay.rb
@@ -103,45 +103,45 @@ module OffsitePayments #:nodoc:
         end
 
         def item_id
-          params['orderid']
+          decode(params['orderid'])
         end
 
         def transaction_id
-          params['tranID']
+          decode(params['tranID'])
         end
 
         def account
-          params["domain"]
+          decode(params['domain'])
         end
 
         # the money amount we received in X.2 decimal.
         def gross
-          params['amount']
+          decode(params['amount'])
         end
 
         def currency
-          params['currency']
+          decode(params['currency'])
         end
 
         def channel
-          params['channel']
+          decode(params['channel'])
         end
 
         # When was this payment received by the client.
         def received_at
-          params['paydate']
+          decode(params['paydate'])
         end
 
         def auth_code
-          params['appcode']
+          decode(params['appcode'])
         end
 
         def error_code
-          params['error_code']
+          decode(params['error_code'])
         end
 
         def error_desc
-          params['error_desc']
+          decode(params['error_desc'])
         end
 
         def security_key
@@ -171,6 +171,11 @@ module OffsitePayments #:nodoc:
         def generate_signature
           key0 = Digest::MD5.hexdigest("#{transaction_id}#{item_id}#{status_orig}#{account}#{gross}#{currency}")
           Digest::MD5.hexdigest("#{received_at}#{account}#{key0}#{auth_code}#{@options[:credential2]}")
+        end
+        
+        def decode param
+          return nil if param.nil?
+          URI.decode(param)
         end
       end
 

--- a/test/unit/integrations/molpay/molpay_helper_test.rb
+++ b/test/unit/integrations/molpay/molpay_helper_test.rb
@@ -7,7 +7,7 @@ class MolpayHelperTest < Test::Unit::TestCase
     @helper = Molpay::Helper.new('order-5.00','molpaytech', :amount => 5.00, :currency => 'MYR', :credential2 => 'testcredential')
   end
  
- def test_basic_helper_fields
+  def test_basic_helper_fields
     assert_field "merchantid", "molpaytech"
     assert_field "amount", "5.00"
     assert_field "orderid", "order-5.00"

--- a/test/unit/integrations/molpay/molpay_notification_test.rb
+++ b/test/unit/integrations/molpay/molpay_notification_test.rb
@@ -59,6 +59,12 @@ class MolpayNotificationTest < Test::Unit::TestCase
     refute molpay.acknowledge
   end
 
+  def test_urldecoded_paydate
+    raw = http_raw_data(:success_with_urlencoded_paydate)
+    molpay = Molpay::Notification.new(raw)
+    assert_not_equal(molpay.received_at, molpay.params['paydate'])
+    assert_not_match(/\%[0-9A-F][0-9A-F]|\+/, molpay.received_at)
+  end
 
   private
 
@@ -77,6 +83,9 @@ class MolpayNotificationTest < Test::Unit::TestCase
 
     case mode
     when :success
+      basedata.collect {|k,v| "#{k}=#{CGI.escape(v.to_s)}"}.join('&')
+    when :success_with_urlencoded_paydate
+      basedata['paydate'] = '2019-04-15%2012%3A08%3A47'
       basedata.collect {|k,v| "#{k}=#{CGI.escape(v.to_s)}"}.join('&')
     when :payment_failed
       basedata.merge("status" => "11", "error_code" => "404", "error_desc" => "Payment Failed").collect {|k,v| "#{k}=#{CGI.escape(v.to_s)}"}.join('&')


### PR DESCRIPTION
This PR includes fix for a bug where incorrect signature being generated due to urlencoded `paydate` field.
Also fixed warning from unit test where there is unmatched indent in `test/unit/integrations/molpay/molpay_helper_test.rb` file.

Test Run Result:
```
$ bundle exec rake
/home/haziman/.rbenv/versions/2.6.1/bin/ruby -w -I"lib:test" -I"/home/haziman/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.0/lib" "/home/haziman/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.0/lib/rake/rake_test_loader.rb" "test/unit/integrations/molpay/molpay_helper_test.rb" "test/unit/integrations/molpay/molpay_module_test.rb" "test/unit/integrations/molpay/molpay_notification_test.rb" "test/unit/integrations/molpay/molpay_return_test.rb"
/home/haziman/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/activesupport-5.1.5/lib/active_support/core_ext/hash/slice.rb:21: warning: method redefined; discarding
old slice
Loaded suite /home/haziman/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.0/lib/rake/rake_test_loader
Started
/home/haziman/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/active_utils-3.3.16/lib/active_utils/connection.rb:26: warning: method redefined; discarding old retry_safe
/home/haziman/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/active_utils-3.3.16/lib/active_utils/connection.rb:26: warning: method redefined; discarding old retry_safe=
..............................
Finished in 0.5212705 seconds.
---------------------------------------------------------------------------------------------------------------------------------------------------------------------30 tests, 62 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
---------------------------------------------------------------------------------------------------------------------------------------------------------------------57.55 tests/s, 118.94 assertions/s
```

Real-world Testing:

Using the following code:

![image](https://user-images.githubusercontent.com/2503209/56121294-6546f300-5fa2-11e9-9de9-a99685926a0a.png)

Before fix is applied:

![image](https://user-images.githubusercontent.com/2503209/56121502-d71f3c80-5fa2-11e9-8e2e-381a9cb93e6c.png)

Test using urlencoded paydate:

![image](https://user-images.githubusercontent.com/2503209/56121400-9c1d0900-5fa2-11e9-97e0-8d336e7b8dac.png)

Test using non-urlencoded paydate:

![image](https://user-images.githubusercontent.com/2503209/56121432-b3f48d00-5fa2-11e9-9bf9-845af2373cea.png)

