### PR TITLE
Bitpay/allow for api v2 tokens

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,8 @@ GEM
     arel (9.0.0)
     builder (3.2.3)
     concurrent-ruby (1.1.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.4)
     daemons (1.0.10)
     domain_name (0.5.20170404)
@@ -70,6 +72,7 @@ GEM
     gem_plugin (0.2.3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashdiff (0.3.9)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.9.5)
@@ -144,6 +147,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rake (12.3.2)
+    safe_yaml (1.0.5)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -160,6 +164,10 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
+    webmock (3.5.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     webrobots (0.1.2)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
@@ -180,6 +188,7 @@ DEPENDENCIES
   rake
   test-unit (~> 3.0)
   thor
+  webmock
 
 BUNDLED WITH
    1.17.3

--- a/lib/offsite_payments/integrations/bit_pay.rb
+++ b/lib/offsite_payments/integrations/bit_pay.rb
@@ -1,11 +1,12 @@
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module BitPay
+      API_V1_URL = 'https://bitpay.com/api/invoice'
+      API_V1_TOKEN_REGEX = /[0OIl]/
+      API_V2_URL = 'https://bitpay.com/invoices'
+
       mattr_accessor :service_url
       self.service_url = 'https://bitpay.com/invoice'
-
-      mattr_accessor :invoicing_url
-      self.invoicing_url = 'https://bitpay.com/api/invoice'
 
       def self.notification(post, options = {})
         Notification.new(post, options)
@@ -17,6 +18,18 @@ module OffsitePayments #:nodoc:
 
       def self.return(query_string, options = {})
         Return.new(query_string)
+      end
+
+      def self.v2_api_token?(api_token)
+        api_token.length >= 44 && !API_V1_TOKEN_REGEX.match(api_token)
+      end
+
+      def self.invoicing_url(api_token)
+        if v2_api_token?(api_token)
+          API_V2_URL
+        else
+          API_V1_URL
+        end
       end
 
       class Helper < OffsitePayments::Helper
@@ -63,7 +76,7 @@ module OffsitePayments #:nodoc:
         private
 
         def create_invoice
-          uri = URI.parse(BitPay.invoicing_url)
+          uri = URI.parse(BitPay.invoicing_url(@account))
           http = Net::HTTP.new(uri.host, uri.port)
           http.use_ssl = true
 
@@ -115,7 +128,7 @@ module OffsitePayments #:nodoc:
         end
 
         def acknowledge(authcode = nil)
-          uri = URI.parse("#{OffsitePayments::Integrations::BitPay.invoicing_url}/#{transaction_id}")
+          uri = URI.parse("#{OffsitePayments::Integrations::BitPay.invoicing_url(@options[:credential1])}/#{transaction_id}")
 
           http = Net::HTTP.new(uri.host, uri.port)
           http.use_ssl = true

--- a/offsite_payments.gemspec
+++ b/offsite_payments.gemspec
@@ -51,4 +51,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('mocha', '~> 1.0')
   s.add_development_dependency('rails', '>= 3.2.14')
   s.add_development_dependency('thor')
+  s.add_development_dependency('webmock')
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ require 'bundler/setup'
 
 require 'test/unit'
 require 'mocha/test_unit'
+require 'webmock/test_unit'
 
 require 'money'
 require 'yaml'

--- a/test/unit/integrations/bit_pay/bit_pay_helper_test.rb
+++ b/test/unit/integrations/bit_pay/bit_pay_helper_test.rb
@@ -4,7 +4,10 @@ class BitPayHelperTest < Test::Unit::TestCase
   include OffsitePayments::Integrations
 
   def setup
-    @helper = BitPay::Helper.new(1234, 'cody@example.com', :amount => 500, :currency => 'USD')
+    @token_v1 = 'g82hEYhfRkhIlX5HJEqO8w5giRVeyGwsJ1wDPRvx8'
+    @token_v2 = '5v2K2rwuWQbnKexiQF9Eu6xdCVg7HFtkFNXarGEq9vLR'
+    @invoice_id = '98kui1gJ7FocK41gUaBZxG'
+    @helper = BitPay::Helper.new(1234, @token_v1, :amount => 500, :currency => 'USD')
   end
 
   def test_basic_helper_fields
@@ -45,9 +48,41 @@ class BitPayHelperTest < Test::Unit::TestCase
     assert_equal fields, @helper.fields
   end
 
-  def test_form_fields_uses_invoice_id
-    Net::HTTP.any_instance.expects(:request).returns(stub(:body => '{"id": "98kui1gJ7FocK41gUaBZxG"}'))
+  def test_calls_the_v1_api_url_when_the_token_is_v1
+    stub_request(:post, BitPay::API_V1_URL).with(
+      body: {
+        orderID: '1234',
+        price: '500',
+        currency: 'USD',
+        posData: { orderId: 1234 }.to_json,
+        fullNotifications: "true",
+        transactionSpeed: 'high',
+      }.to_json
+    ).to_return(
+      status: 200,
+      body: { id: @invoice_id }.to_json
+    )
 
-    assert_equal '98kui1gJ7FocK41gUaBZxG', @helper.form_fields['id']
+    assert_equal @invoice_id, @helper.form_fields['id']
+  end
+
+  def test_calls_the_v2_api_url_when_the_token_is_v2
+    stub_request(:post, BitPay::API_V2_URL).with(
+      body: {
+        orderID: '1234',
+        price: '500',
+        currency: 'USD',
+        posData: { orderId: 1234 }.to_json,
+        fullNotifications: "true",
+        transactionSpeed: 'high',
+      }.to_json
+    ).to_return(
+      status: 200,
+      body: { id: @invoice_id }.to_json
+    )
+
+    helper = BitPay::Helper.new(1234, @token_v2, :amount => 500, :currency => 'USD')
+
+    assert_equal @invoice_id, helper.form_fields['id']
   end
 end

--- a/test/unit/integrations/bit_pay/bit_pay_module_test.rb
+++ b/test/unit/integrations/bit_pay/bit_pay_module_test.rb
@@ -10,4 +10,34 @@ class BitPayModuleTest < Test::Unit::TestCase
   def test_return_method
     assert_instance_of BitPay::Return, BitPay.return('{"name":"cody"}', {})
   end
+
+  def test_invoicing_url_returns_v1_url_when_token_is_less_than_44
+    api_token = 'a' * 43
+
+    assert_equal BitPay::API_V1_URL, BitPay.invoicing_url(api_token)
+  end
+
+  def test_invoicing_url_returns_v1_url_when_token_is_equal_to_44_and_contains_special_chars
+    api_token = ('a' * 43)
+
+    %w(0 O I l).each do |char|
+      assert_equal BitPay::API_V1_URL, BitPay.invoicing_url(api_token + char)
+    end
+  end
+
+  def test_invoicing_url_returns_v1_url_when_token_is_bigger_than_44_and_contains_special_chars
+    api_token = ('a' * 46)
+
+    %w(0 O I l).each do |char|
+      assert_equal BitPay::API_V1_URL, BitPay.invoicing_url(api_token + char)
+    end
+  end
+
+  def test_invoicing_url_returns_v1_url_when_token_is_equal_to_44_and_does_not_contain_special_chars
+    assert_equal BitPay::API_V2_URL, BitPay.invoicing_url('a' * 44)
+  end
+
+  def test_invoicing_url_returns_v1_url_when_token_is_bigger_than_44_and_does_not_contain_special_chars
+    assert_equal BitPay::API_V2_URL, BitPay.invoicing_url('a' * 45)
+  end
 end

--- a/test/unit/integrations/bit_pay/bit_pay_notification_test.rb
+++ b/test/unit/integrations/bit_pay/bit_pay_notification_test.rb
@@ -4,7 +4,10 @@ class BitPayNotificationTest < Test::Unit::TestCase
   include OffsitePayments::Integrations
 
   def setup
-    @bit_pay = BitPay::Notification.new(http_raw_data)
+    @token_v1 = 'g82hEYhfRkhIlX5HJEqO8w5giRVeyGwsJ1wDPRvx8'
+    @token_v2 = '5v2K2rwuWQbnKexiQF9Eu6xdCVg7HFtkFNXarGEq9vLR'
+    @invoice_id = '98kui1gJ7FocK41gUaBZxG'
+    @bit_pay = BitPay::Notification.new(http_raw_data, credential1: @token_v1)
   end
 
   def test_accessors
@@ -21,20 +24,33 @@ class BitPayNotificationTest < Test::Unit::TestCase
     assert_equal Money.from_amount(10.00, 'USD'), @bit_pay.amount
   end
 
-  def test_successful_acknowledgement
-    Net::HTTP.any_instance.expects(:request).returns(stub(:body => http_raw_data))
+  def test_successful_acknowledgement_with_v1_api_token
+    stub_request(:get, "#{BitPay.invoicing_url(@token_v1)}/#{@invoice_id}").
+      to_return(status: 200, body: http_raw_data)
+
     assert @bit_pay.acknowledge
   end
 
+  def test_successful_acknowledgement_with_v2_api_token
+    stub_request(:get, "#{BitPay.invoicing_url(@token_v2)}/#{@invoice_id}").
+      to_return(status: 200, body: http_raw_data)
+
+    notification = BitPay::Notification.new(http_raw_data, credential1: @token_v2)
+
+    assert notification.acknowledge
+  end
+
   def test_acknowledgement_error
-    Net::HTTP.any_instance.expects(:request).returns(stub(:body => '{"error":"Doesnt match"}'))
+    stub_request(:get, "#{BitPay.invoicing_url(@token_v1)}/#{@invoice_id}").
+      to_return(status: 200, body: { error: 'Doesnt match'}.to_json)
+
     assert !@bit_pay.acknowledge
   end
 
   private
   def http_raw_data
     {
-      "id"=>"98kui1gJ7FocK41gUaBZxG",
+      "id"=> @invoice_id,
       "orderID"=>"123",
       "url"=>"https://bitpay.com/invoice/98kui1gJ7FocK41gUaBZxG",
       "status"=>"complete",

--- a/test/unit/integrations/molpay/molpay_helper_test.rb
+++ b/test/unit/integrations/molpay/molpay_helper_test.rb
@@ -2,11 +2,13 @@ require 'test_helper'
 
 class MolpayHelperTest < Test::Unit::TestCase
   include OffsitePayments::Integrations
-  
+
   def setup
+    ::WebMock.allow_net_connect!
+
     @helper = Molpay::Helper.new('order-5.00','molpaytech', :amount => 5.00, :currency => 'MYR', :credential2 => 'testcredential')
   end
- 
+
  def test_basic_helper_fields
     assert_field "merchantid", "molpaytech"
     assert_field "amount", "5.00"
@@ -20,7 +22,7 @@ class MolpayHelperTest < Test::Unit::TestCase
 
   def test_credential_based_url_optional
     molpay = Molpay::Helper.new('order-5.00','molpaytech', :amount => 5.00, :currency => 'MYR', :credential2 => 'testcredential', :channel => 'maybank2u.php')
-    assert_equal 'https://www.onlinepayment.com.my/MOLPay/pay/molpaytech/maybank2u.php', molpay.credential_based_url 
+    assert_equal 'https://www.onlinepayment.com.my/MOLPay/pay/molpaytech/maybank2u.php', molpay.credential_based_url
   end
 
   def test_customer_fields
@@ -38,7 +40,7 @@ class MolpayHelperTest < Test::Unit::TestCase
   def test_supported_currency
     ['MYR', 'USD', 'SGD', 'PHP', 'VND', 'IDR', 'AUD', 'CNY', 'THB', 'GBP', 'EUR', 'HKD'].each do |cur|
       @helper.currency cur
-      assert_field "cur", cur 
+      assert_field "cur", cur
     end
   end
 
@@ -65,7 +67,7 @@ class MolpayHelperTest < Test::Unit::TestCase
     @helper.return_url "http://www.example.com"
     assert_field "returnurl", "http://www.example.com"
   end
-  
+
   def test_notify_url
     @helper.notify_url "http://www.example.com"
     assert_field "callbackurl", "http://www.example.com"

--- a/test/unit/integrations/molpay/molpay_notification_test.rb
+++ b/test/unit/integrations/molpay/molpay_notification_test.rb
@@ -4,6 +4,8 @@ class MolpayNotificationTest < Test::Unit::TestCase
   include OffsitePayments::Integrations
 
   def setup
+    ::WebMock.allow_net_connect!
+
     @amount = "10.00"
     @secret_key = "molpay_skey"
     @account = "molpaytest"


### PR DESCRIPTION
Bitpay is deprecating its previous API. Both API can be differentiated based on the API token used. Current merchant won't be impacted by this change since their API token doesn't match the requirements for the V2 API, V1 uses base64 and V2 is base58 and base58 shouldn’t include those characters `0OIl`.