### PR TITLE
[Bitpay] Add token to payload while creating the invoice

### DIFF
--- a/lib/offsite_payments/integrations/bit_pay.rb
+++ b/lib/offsite_payments/integrations/bit_pay.rb
@@ -40,6 +40,7 @@ module OffsitePayments #:nodoc:
           add_field('posData', {'orderId' => order_id}.to_json)
           add_field('fullNotifications', true)
           add_field('transactionSpeed', 'high')
+          add_field('token', account)
         end
 
         mapping :amount, 'price'

--- a/test/unit/integrations/bit_pay/bit_pay_helper_test.rb
+++ b/test/unit/integrations/bit_pay/bit_pay_helper_test.rb
@@ -57,6 +57,7 @@ class BitPayHelperTest < Test::Unit::TestCase
         posData: { orderId: 1234 }.to_json,
         fullNotifications: "true",
         transactionSpeed: 'high',
+        token: @token_v1,
       }.to_json
     ).to_return(
       status: 200,
@@ -75,6 +76,7 @@ class BitPayHelperTest < Test::Unit::TestCase
         posData: { orderId: 1234 }.to_json,
         fullNotifications: "true",
         transactionSpeed: 'high',
+        token: @token_v2,
       }.to_json
     ).to_return(
       status: 200,


### PR DESCRIPTION
The V2 API needs the token upon invoice creation, as per BitPay people
it's also fine to pass it to V1