### PR TITLE
[Bitpay] Add token check for API v2 endpoints

### DIFF
--- a/lib/offsite_payments/integrations/bit_pay.rb
+++ b/lib/offsite_payments/integrations/bit_pay.rb
@@ -86,6 +86,7 @@ module OffsitePayments #:nodoc:
           request.body = @fields.to_json
 
           unless v2_api_token?(@account)
+            request.add_field("x-bitpay-plugin-info", "BitPay_Shopify_Client_v2.0.1906")
             request.basic_auth @account, ''
           end
 

--- a/lib/offsite_payments/integrations/bit_pay.rb
+++ b/lib/offsite_payments/integrations/bit_pay.rb
@@ -2,7 +2,7 @@ module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module BitPay
       API_V1_URL = 'https://bitpay.com/api/invoice'
-      API_V1_TOKEN_REGEX = /[0OIl]/
+      API_V2_TOKEN_REGEX = /^[^0OIl]{44,}$/
       API_V2_URL = 'https://bitpay.com/invoices'
 
       mattr_accessor :service_url
@@ -21,7 +21,7 @@ module OffsitePayments #:nodoc:
       end
 
       def self.v2_api_token?(api_token)
-        api_token.length >= 44 && !API_V1_TOKEN_REGEX.match(api_token)
+        API_V2_TOKEN_REGEX.match(api_token)
       end
 
       def self.invoicing_url(api_token)
@@ -84,7 +84,10 @@ module OffsitePayments #:nodoc:
           request = Net::HTTP::Post.new(uri.request_uri)
           request.content_type = "application/json"
           request.body = @fields.to_json
-          request.basic_auth @account, ''
+
+          unless v2_api_token?(@account)
+            request.basic_auth @account, ''
+          end
 
           response = http.request(request)
           JSON.parse(response.body)

--- a/test/unit/integrations/bit_pay/bit_pay_helper_test.rb
+++ b/test/unit/integrations/bit_pay/bit_pay_helper_test.rb
@@ -58,7 +58,8 @@ class BitPayHelperTest < Test::Unit::TestCase
         fullNotifications: "true",
         transactionSpeed: 'high',
         token: @token_v1,
-      }.to_json
+      }.to_json,
+      basic_auth: [@token_v1, ''],
     ).to_return(
       status: 200,
       body: { id: @invoice_id }.to_json


### PR DESCRIPTION
BitPay gateway implements API v2 authentication for newer implementations