### PR TITLE
[BitPay] properly fetch the invoice id after creation

### DIFF
--- a/lib/offsite_payments/integrations/bit_pay.rb
+++ b/lib/offsite_payments/integrations/bit_pay.rb
@@ -85,7 +85,7 @@ module OffsitePayments #:nodoc:
           request.content_type = "application/json"
           request.body = @fields.to_json
 
-          unless v2_api_token?(@account)
+          unless BitPay.v2_api_token?(@account)
             request.add_field("x-bitpay-plugin-info", "BitPay_Shopify_Client_v2.0.1906")
             request.basic_auth @account, ''
           end

--- a/lib/offsite_payments/integrations/bit_pay.rb
+++ b/lib/offsite_payments/integrations/bit_pay.rb
@@ -71,7 +71,7 @@ module OffsitePayments #:nodoc:
 
           raise ActionViewHelperError, "Invalid response while retrieving BitPay Invoice ID. Please try again." unless invoice
 
-          {"id" => invoice['id']}
+          { "id" => extract_invoice_id(invoice) }
         end
 
         private
@@ -92,6 +92,14 @@ module OffsitePayments #:nodoc:
 
           response = http.request(request)
           JSON.parse(response.body)
+        end
+
+        def extract_invoice_id(invoice)
+          if BitPay.v2_api_token?(@account)
+            invoice['data']['id']
+          else
+            invoice['id']
+          end
         end
       end
 

--- a/test/unit/integrations/bit_pay/bit_pay_helper_test.rb
+++ b/test/unit/integrations/bit_pay/bit_pay_helper_test.rb
@@ -81,7 +81,7 @@ class BitPayHelperTest < Test::Unit::TestCase
       }.to_json
     ).to_return(
       status: 200,
-      body: { id: @invoice_id }.to_json
+      body: { data: { id: @invoice_id } }.to_json
     )
 
     helper = BitPay::Helper.new(1234, @token_v2, :amount => 500, :currency => 'USD')


### PR DESCRIPTION
The v1 logic was fetching the invoice id using `invoice['id']` and this was used also by v2.
This change makes v2 use `invoice['data']['id']`