### PR TITLE
[BitPay] Read information from the `data` key present in the payload instead of root

### DIFF
--- a/lib/offsite_payments/integrations/bit_pay.rb
+++ b/lib/offsite_payments/integrations/bit_pay.rb
@@ -141,7 +141,7 @@ module OffsitePayments #:nodoc:
         end
 
         def acknowledge(authcode = nil)
-          uri = URI.parse("#{OffsitePayments::Integrations::BitPay.invoicing_url(@options[:credential1])}/#{transaction_id}")
+          uri = URI.parse("#{OffsitePayments::Integrations::BitPay::API_V2_URL}/#{transaction_id}")
 
           http = Net::HTTP.new(uri.host, uri.port)
           http.use_ssl = true
@@ -151,9 +151,9 @@ module OffsitePayments #:nodoc:
 
           response = http.request(request)
 
-          posted_json = JSON.parse(@raw).tap { |j| j.delete('currentTime') }
+          posted_json = comparable_data
           parse(response.body)
-          retrieved_json = JSON.parse(@raw).tap { |j| j.delete('currentTime') }
+          retrieved_json = comparable_data
 
           posted_json == retrieved_json
         end
@@ -161,7 +161,11 @@ module OffsitePayments #:nodoc:
         private
         def parse(body)
           @raw = body
-          @params = JSON.parse(@raw)
+          @params = JSON.parse(@raw)['data']
+        end
+
+        def comparable_data
+          @params&.reject { |k, _v| k == 'currentTime' }
         end
       end
 

--- a/lib/offsite_payments/integrations/bit_pay.rb
+++ b/lib/offsite_payments/integrations/bit_pay.rb
@@ -147,8 +147,6 @@ module OffsitePayments #:nodoc:
           http.use_ssl = true
 
           request = Net::HTTP::Get.new(uri.path)
-          request.basic_auth @options[:credential1], ''
-
           response = http.request(request)
 
           posted_json = comparable_data

--- a/test/unit/integrations/bit_pay/bit_pay_notification_test.rb
+++ b/test/unit/integrations/bit_pay/bit_pay_notification_test.rb
@@ -4,10 +4,9 @@ class BitPayNotificationTest < Test::Unit::TestCase
   include OffsitePayments::Integrations
 
   def setup
-    @token_v1 = 'g82hEYhfRkhIlX5HJEqO8w5giRVeyGwsJ1wDPRvx8'
-    @token_v2 = '5v2K2rwuWQbnKexiQF9Eu6xdCVg7HFtkFNXarGEq9vLR'
+    @token = 'g82hEYhfRkhIlX5HJEqO8w5giRVeyGwsJ1wDPRvx8'
     @invoice_id = '98kui1gJ7FocK41gUaBZxG'
-    @bit_pay = BitPay::Notification.new(http_raw_data, credential1: @token_v1)
+    @bit_pay = BitPay::Notification.new(http_raw_data, credential1: @token)
   end
 
   def test_accessors
@@ -24,20 +23,11 @@ class BitPayNotificationTest < Test::Unit::TestCase
     assert_equal Money.from_amount(10.00, 'USD'), @bit_pay.amount
   end
 
-  def test_successful_acknowledgement_with_v1_api_token
+  def test_successful_acknowledgement
     stub_request(:get, "#{BitPay::API_V2_URL}/#{@invoice_id}")
       .to_return(status: 200, body: http_raw_data)
 
     assert @bit_pay.acknowledge
-  end
-
-  def test_successful_acknowledgement_with_v2_api_token
-    stub_request(:get, "#{BitPay::API_V2_URL}/#{@invoice_id}")
-      .to_return(status: 200, body: http_raw_data)
-
-    notification = BitPay::Notification.new(http_raw_data, credential1: @token_v2)
-
-    assert notification.acknowledge
   end
 
   def test_acknowledgement_error

--- a/test/unit/integrations/bit_pay/bit_pay_notification_test.rb
+++ b/test/unit/integrations/bit_pay/bit_pay_notification_test.rb
@@ -25,15 +25,17 @@ class BitPayNotificationTest < Test::Unit::TestCase
   end
 
   def test_successful_acknowledgement_with_v1_api_token
-    stub_request(:get, "#{BitPay.invoicing_url(@token_v1)}/#{@invoice_id}").
-      to_return(status: 200, body: http_raw_data)
+    stub_request(:get, "#{BitPay::API_V2_URL}/#{@invoice_id}")
+      .with(basic_auth: [@token_v1, ''])
+      .to_return(status: 200, body: http_raw_data)
 
     assert @bit_pay.acknowledge
   end
 
   def test_successful_acknowledgement_with_v2_api_token
-    stub_request(:get, "#{BitPay.invoicing_url(@token_v2)}/#{@invoice_id}").
-      to_return(status: 200, body: http_raw_data)
+    stub_request(:get, "#{BitPay::API_V2_URL}/#{@invoice_id}")
+      .with(basic_auth: [@token_v2, ''])
+      .to_return(status: 200, body: http_raw_data)
 
     notification = BitPay::Notification.new(http_raw_data, credential1: @token_v2)
 
@@ -41,8 +43,9 @@ class BitPayNotificationTest < Test::Unit::TestCase
   end
 
   def test_acknowledgement_error
-    stub_request(:get, "#{BitPay.invoicing_url(@token_v1)}/#{@invoice_id}").
-      to_return(status: 200, body: { error: 'Doesnt match'}.to_json)
+    stub_request(:get, "#{BitPay::API_V2_URL}/#{@invoice_id}")
+      .with(basic_auth: [@token_v1, ''])
+      .to_return(status: 200, body: { error: 'Doesnt match'}.to_json)
 
     assert !@bit_pay.acknowledge
   end
@@ -50,17 +53,19 @@ class BitPayNotificationTest < Test::Unit::TestCase
   private
   def http_raw_data
     {
-      "id"=> @invoice_id,
-      "orderID"=>"123",
-      "url"=>"https://bitpay.com/invoice/98kui1gJ7FocK41gUaBZxG",
-      "status"=>"complete",
-      "btcPrice"=>"0.0295",
-      "price"=>"10.00",
-      "currency"=>"USD",
-      "invoiceTime"=>"1370539476654",
-      "expirationTime"=>"1370540376654",
-      "currentTime"=>"1370539573956",
-      "posData" => '{"orderId":123}'
+      "data" => {
+        "id"=> @invoice_id,
+        "orderID"=>"123",
+        "url"=>"https://bitpay.com/invoice/98kui1gJ7FocK41gUaBZxG",
+        "status"=>"complete",
+        "btcPrice"=>"0.0295",
+        "price"=>"10.00",
+        "currency"=>"USD",
+        "invoiceTime"=>"1370539476654",
+        "expirationTime"=>"1370540376654",
+        "currentTime"=>"1370539573956",
+        "posData" => '{"orderId":123}'
+      }
     }.to_json
   end
 end

--- a/test/unit/integrations/bit_pay/bit_pay_notification_test.rb
+++ b/test/unit/integrations/bit_pay/bit_pay_notification_test.rb
@@ -26,7 +26,6 @@ class BitPayNotificationTest < Test::Unit::TestCase
 
   def test_successful_acknowledgement_with_v1_api_token
     stub_request(:get, "#{BitPay::API_V2_URL}/#{@invoice_id}")
-      .with(basic_auth: [@token_v1, ''])
       .to_return(status: 200, body: http_raw_data)
 
     assert @bit_pay.acknowledge
@@ -34,7 +33,6 @@ class BitPayNotificationTest < Test::Unit::TestCase
 
   def test_successful_acknowledgement_with_v2_api_token
     stub_request(:get, "#{BitPay::API_V2_URL}/#{@invoice_id}")
-      .with(basic_auth: [@token_v2, ''])
       .to_return(status: 200, body: http_raw_data)
 
     notification = BitPay::Notification.new(http_raw_data, credential1: @token_v2)
@@ -44,7 +42,6 @@ class BitPayNotificationTest < Test::Unit::TestCase
 
   def test_acknowledgement_error
     stub_request(:get, "#{BitPay::API_V2_URL}/#{@invoice_id}")
-      .with(basic_auth: [@token_v1, ''])
       .to_return(status: 200, body: { error: 'Doesnt match'}.to_json)
 
     assert !@bit_pay.acknowledge


### PR DESCRIPTION
The previous version of the  BitPay integration was returning the payload directly in the root
of the json payload. This now needs to be accessed through the `data` key. See https://bitpay.com/invoices/VAGTTqCZJFSiQpuXW2pFTD for an example.