### PR TITLE
[Bitpay] Fixes an issue where notification couldn't be acknowledged

### DIFF
--- a/lib/offsite_payments/integrations/bit_pay.rb
+++ b/lib/offsite_payments/integrations/bit_pay.rb
@@ -159,7 +159,9 @@ module OffsitePayments #:nodoc:
         private
         def parse(body)
           @raw = body
-          @params = JSON.parse(@raw)['data']
+          json = JSON.parse(@raw)
+
+          @params = json.key?('data') ? json['data'] : json
         end
 
         def comparable_data

--- a/test/unit/integrations/bit_pay/bit_pay_notification_test.rb
+++ b/test/unit/integrations/bit_pay/bit_pay_notification_test.rb
@@ -6,7 +6,7 @@ class BitPayNotificationTest < Test::Unit::TestCase
   def setup
     @token = 'g82hEYhfRkhIlX5HJEqO8w5giRVeyGwsJ1wDPRvx8'
     @invoice_id = '98kui1gJ7FocK41gUaBZxG'
-    @bit_pay = BitPay::Notification.new(http_raw_data, credential1: @token)
+    @bit_pay = BitPay::Notification.new(http_raw_data.to_json, credential1: @token)
   end
 
   def test_accessors
@@ -25,7 +25,7 @@ class BitPayNotificationTest < Test::Unit::TestCase
 
   def test_successful_acknowledgement
     stub_request(:get, "#{BitPay::API_V2_URL}/#{@invoice_id}")
-      .to_return(status: 200, body: http_raw_data)
+      .to_return(status: 200, body: http_raw_api_data.to_json)
 
     assert @bit_pay.acknowledge
   end
@@ -40,19 +40,23 @@ class BitPayNotificationTest < Test::Unit::TestCase
   private
   def http_raw_data
     {
-      "data" => {
-        "id"=> @invoice_id,
-        "orderID"=>"123",
-        "url"=>"https://bitpay.com/invoice/98kui1gJ7FocK41gUaBZxG",
-        "status"=>"complete",
-        "btcPrice"=>"0.0295",
-        "price"=>"10.00",
-        "currency"=>"USD",
-        "invoiceTime"=>"1370539476654",
-        "expirationTime"=>"1370540376654",
-        "currentTime"=>"1370539573956",
-        "posData" => '{"orderId":123}'
-      }
-    }.to_json
+      "id"=> @invoice_id,
+      "orderID"=>"123",
+      "url"=>"https://bitpay.com/invoice/98kui1gJ7FocK41gUaBZxG",
+      "status"=>"complete",
+      "btcPrice"=>"0.0295",
+      "price"=>"10.00",
+      "currency"=>"USD",
+      "invoiceTime"=>"1370539476654",
+      "expirationTime"=>"1370540376654",
+      "currentTime"=>"1370539573956",
+      "posData" => '{"orderId":123}'
+    }
+  end
+
+  def http_raw_api_data
+    {
+      "data" => http_raw_data
+    }
   end
 end


### PR DESCRIPTION
Previous changes to BitPay https://github.com/activemerchant/offsite_payments/pull/328 introduced a bug since the payload from an API and the payload present on the api aren't similar. This will set the params of the notification to `JSON.parse(body)['data']` if there is a `data` key or will set it to `JSON.parse(body) otherwise.