### PR TITLE
[BitPay] Only compare transaction_id/status while acknowledging

### DIFF
--- a/lib/offsite_payments/integrations/bit_pay.rb
+++ b/lib/offsite_payments/integrations/bit_pay.rb
@@ -149,11 +149,11 @@ module OffsitePayments #:nodoc:
           request = Net::HTTP::Get.new(uri.path)
           response = http.request(request)
 
-          posted_json = comparable_data
-          parse(response.body)
-          retrieved_json = comparable_data
+          received_attributes = [transaction_id, status]
 
-          posted_json == retrieved_json
+          parse(response.body)
+
+          received_attributes == [transaction_id, status]
         end
 
         private
@@ -162,10 +162,6 @@ module OffsitePayments #:nodoc:
           json = JSON.parse(@raw)
 
           @params = json.key?('data') ? json['data'] : json
-        end
-
-        def comparable_data
-          @params&.reject { |k, _v| k == 'currentTime' }
         end
       end
 

--- a/test/unit/integrations/bit_pay/bit_pay_notification_test.rb
+++ b/test/unit/integrations/bit_pay/bit_pay_notification_test.rb
@@ -30,6 +30,20 @@ class BitPayNotificationTest < Test::Unit::TestCase
     assert @bit_pay.acknowledge
   end
 
+  def test_acknowledgement_fails_when_transaction_id_doesnt_match
+    stub_request(:get, "#{BitPay::API_V2_URL}/#{@invoice_id}")
+      .to_return(status: 200, body: http_raw_api_data("id" => "bad_id").to_json)
+
+    refute @bit_pay.acknowledge
+  end
+
+  def test_acknowledgement_fails_when_status_doesnt_match
+    stub_request(:get, "#{BitPay::API_V2_URL}/#{@invoice_id}")
+      .to_return(status: 200, body: http_raw_api_data("status" => "failure").to_json)
+
+    refute @bit_pay.acknowledge
+  end
+
   def test_acknowledgement_error
     stub_request(:get, "#{BitPay::API_V2_URL}/#{@invoice_id}")
       .to_return(status: 200, body: { error: 'Doesnt match'}.to_json)
@@ -54,9 +68,9 @@ class BitPayNotificationTest < Test::Unit::TestCase
     }
   end
 
-  def http_raw_api_data
+  def http_raw_api_data(options = {})
     {
-      "data" => http_raw_data
+      "data" => http_raw_data.merge(options)
     }
   end
 end


### PR DESCRIPTION
Previous of the code was comparing the whole payload between the IPN and the API request. This is causing issues because payload have evovled quite a lot since this integration was written. This only compares transaction_id/status which are certified to be present in both payload.