### PR TITLE
[Realex] Use application_id instead of hardcoded Shopify

### DIFF
--- a/lib/offsite_payments/integrations/realex_offsite.rb
+++ b/lib/offsite_payments/integrations/realex_offsite.rb
@@ -240,7 +240,7 @@ module OffsitePayments #:nodoc:
           add_field 'X-CURRENCY', @currency
           add_field 'X-TEST', @test.to_s
           add_field 'ORDER_ID', "#{order}#{@timestamp.to_i}"
-          add_field 'COMMENT1', 'Shopify'
+          add_field 'COMMENT1', application_id
         end
 
         def form_fields

--- a/test/unit/integrations/realex_offsite/realex_offsite_helper_test.rb
+++ b/test/unit/integrations/realex_offsite/realex_offsite_helper_test.rb
@@ -15,6 +15,7 @@ class RealexOffsiteHelperTest < Test::Unit::TestCase
   end
 
   def setup
+    OffsitePayments::Integrations::RealexOffsite::Helper.application_id = 'Shopify'
     @helper = RealexOffsite::Helper.new('order-500', 'merchant-1234', order_attributes)
   end
 
@@ -162,10 +163,13 @@ class RealexOffsiteHelperTest < Test::Unit::TestCase
     assert_field 'HPP_SHIPPING_STATE', nil
   end
 
+  def test_comment1_equals_application_id
+    assert_field 'COMMENT1', 'Shopify'
+  end
+
   def test_comment
     @helper.comment 'This is my fancy comment'
 
-    assert_field 'COMMENT1', 'Shopify'
     assert_field 'COMMENT2', 'This is my fancy comment'
   end
 


### PR DESCRIPTION
`Shopify` is hardcoded as a parameter sent to Realex. There is already a pattern for this, which is to use the application_id accessor.