### PR TITLE
Remove special subunit case for HUF in universal integration

### DIFF
--- a/lib/offsite_payments.rb
+++ b/lib/offsite_payments.rb
@@ -40,5 +40,5 @@ module OffsitePayments
     self.mode == :test
   end
 
-  CURRENCIES_WITHOUT_FRACTIONS = [ 'BIF', 'BYR', 'CLP', 'CVE', 'DJF', 'GNF', 'HUF', 'ISK', 'JPY', 'KMF', 'KRW', 'PYG', 'RWF', 'TWD', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF' ]
+  CURRENCIES_WITHOUT_FRACTIONS = [ 'BIF', 'BYR', 'CLP', 'CVE', 'DJF', 'GNF', 'ISK', 'JPY', 'KMF', 'KRW', 'PYG', 'RWF', 'TWD', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF' ]
 end

--- a/lib/offsite_payments/integrations/universal.rb
+++ b/lib/offsite_payments/integrations/universal.rb
@@ -22,7 +22,6 @@ module OffsitePayments #:nodoc:
           'CVE' => 0,
           'DJF' => 0,
           'GNF' => 0,
-          'HUF' => 0,
           'ISK' => 0,
           'JPY' => 0,
           'KMF' => 0,


### PR DESCRIPTION
Related to https://github.com/Shopify/shopify/issues/232781

It's generally agreed upon that HUF should have two minor subunits
(ex. https://stripe.com/docs/currencies), instead of the zero subunits
as defined in this gem. This can cause rounding issues when sending to the
gateway. 

By default all currencies have two minor subunits, unless otherwise specified.

https://github.com/activemerchant/offsite_payments/blob/cd56e7897fe91f8dbbfb8185e95449f16e07c921/lib/offsite_payments/integrations/universal.rb#L129-L132

cc @elfassy @pi3r 