### PR TITLE
Test newer rubies and railses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ sudo: false
 cache: bundler
 
 rvm:
+- 2.7
+- 2.6
 - 2.5
-- 2.4
 
 gemfile:
-- gemfiles/Gemfile.rails50
+- gemfiles/Gemfile.rails60
 - gemfiles/Gemfile.latest-release
 - gemfiles/Gemfile.shopify
 

--- a/gemfiles/Gemfile.rails60
+++ b/gemfiles/Gemfile.rails60
@@ -9,5 +9,5 @@ group :remote_test do
   gem 'mongrel', '1.2.0.pre2', :platforms => :ruby
 end
 
-gem 'actionpack', '>= 5.2.3'
+gem 'actionpack', '~> 6.0.0'
 gem 'money', '~> 6.8'

--- a/gemfiles/Gemfile.shopify
+++ b/gemfiles/Gemfile.shopify
@@ -9,5 +9,5 @@ group :remote_test do
   gem 'mongrel', '1.2.0.pre2', :platforms => :ruby
 end
 
-gem 'actionpack', '>= 5.2.3'
+gem 'actionpack', '~> 6.0.0'
 gem 'shopify-money',  require: 'money'

--- a/lib/offsite_payments/integrations/a1agregator.rb
+++ b/lib/offsite_payments/integrations/a1agregator.rb
@@ -93,14 +93,6 @@ module OffsitePayments #:nodoc:
           params['type']
         end
 
-        def partner_income
-          params['partner_income']
-        end
-
-        def system_income
-          params['system_income']
-        end
-
         # Additional notification request params:
         # tid
         # name

--- a/lib/offsite_payments/integrations/bit_pay.rb
+++ b/lib/offsite_payments/integrations/bit_pay.rb
@@ -41,7 +41,7 @@ module OffsitePayments #:nodoc:
           add_field('fullNotifications', true)
           add_field('transactionSpeed', 'high')
           add_field('token', account)
-       end
+        end
 
         mapping :amount, 'price'
         mapping :order, 'orderID'

--- a/lib/offsite_payments/integrations/citrus.rb
+++ b/lib/offsite_payments/integrations/citrus.rb
@@ -119,7 +119,7 @@ module OffsitePayments
         end
 
         def amount
-          Money.from_amount(BigDecimal.new(gross), currency)
+          Money.from_amount(BigDecimal(gross), currency)
         end
 
         def transaction_id
@@ -202,7 +202,7 @@ module OffsitePayments
         end
 
         def status( order_id, order_amount )
-          if @notification.invoice_ok?( order_id ) && @notification.amount_ok?( BigDecimal.new(order_amount) )
+          if @notification.invoice_ok?( order_id ) && @notification.amount_ok?(BigDecimal(order_amount))
             @notification.status
           else
             'Mismatch'

--- a/lib/offsite_payments/integrations/direc_pay.rb
+++ b/lib/offsite_payments/integrations/direc_pay.rb
@@ -320,7 +320,7 @@ module OffsitePayments #:nodoc:
           data = ActiveUtils::PostData.new
           data[:requestparams] = parameters.join('|')
 
-          response = ssl_get("#{url}?#{data.to_post_data}")
+          ssl_get("#{url}?#{data.to_post_data}")
         end
 
         def test?

--- a/lib/offsite_payments/integrations/easy_pay.rb
+++ b/lib/offsite_payments/integrations/easy_pay.rb
@@ -101,7 +101,7 @@ module OffsitePayments #:nodoc:
         end
 
         def amount
-          Money.from_amount(BigDecimal.new(gross), currency)
+          Money.from_amount(BigDecimal(gross), currency)
         end
 
         def item_id

--- a/lib/offsite_payments/integrations/epay.rb
+++ b/lib/offsite_payments/integrations/epay.rb
@@ -125,7 +125,7 @@ module OffsitePayments #:nodoc:
           return false
         end
 
-        %w(txnid orderid currency date time hash fraud payercountry issuercountry txnfee subscriptionid paymenttype cardno).each do |attr|
+        %w(txnid orderid date time hash fraud payercountry issuercountry txnfee subscriptionid paymenttype cardno).each do |attr|
           define_method(attr) do
             params[attr]
           end
@@ -138,7 +138,7 @@ module OffsitePayments #:nodoc:
         def generate_md5string
           md5string = String.new
           for line in @raw.split('&')
-            key, value = *line.scan( %r{^([A-Za-z0-9_.]+)\=(.*)$} ).flatten
+            key, _ = *line.scan( %r{^([A-Za-z0-9_.]+)\=(.*)$} ).flatten
             md5string += params[key] if key != 'hash'
           end
           return md5string + @options[:credential3]

--- a/lib/offsite_payments/integrations/gestpay.rb
+++ b/lib/offsite_payments/integrations/gestpay.rb
@@ -189,7 +189,7 @@ module OffsitePayments #:nodoc:
           response = ssl_get(Gestpay.service_url, decryption_query_string(shop_login, encrypted_string))
           encoded_response = parse_response(response)
           parse_delimited_string(encoded_response, DELIMITER, true)
-        rescue GestpayEncryptionResponseError => e
+        rescue GestpayEncryptionResponseError
           { 'PAY1_TRANSACTIONRESULT' => 'Error' }
         end
 

--- a/lib/offsite_payments/integrations/liqpay.rb
+++ b/lib/offsite_payments/integrations/liqpay.rb
@@ -80,7 +80,7 @@ module OffsitePayments #:nodoc:
         end
 
         def amount
-          Money.from_amount(BigDecimal.new(gross), currency)
+          Money.from_amount(BigDecimal(gross), currency)
         end
 
         def item_id
@@ -156,7 +156,7 @@ module OffsitePayments #:nodoc:
         end
 
         def amount
-          BigDecimal.new(gross)
+          BigDecimal(gross)
         end
 
         def item_id

--- a/lib/offsite_payments/integrations/mollie_ideal.rb
+++ b/lib/offsite_payments/integrations/mollie_ideal.rb
@@ -133,7 +133,7 @@ module OffsitePayments #:nodoc:
         end
 
         def gross_cents
-          (BigDecimal.new(@params['amount'], 2) * 100).to_i
+          (BigDecimal(@params['amount'], 2) * 100).to_i
         end
 
         def status

--- a/lib/offsite_payments/integrations/mollie_mistercash.rb
+++ b/lib/offsite_payments/integrations/mollie_mistercash.rb
@@ -100,7 +100,7 @@ module OffsitePayments #:nodoc:
         end
 
         def gross_cents
-          (BigDecimal.new(@params['amount'], 2) * 100).to_i
+          (BigDecimal(@params['amount'], 2) * 100).to_i
         end
 
         def status

--- a/lib/offsite_payments/integrations/pag_seguro.rb
+++ b/lib/offsite_payments/integrations/pag_seguro.rb
@@ -111,7 +111,7 @@ module OffsitePayments #:nodoc:
           check_for_errors(response, xml)
 
           extract_token(xml)
-        rescue Timeout::Error, Errno::ECONNRESET, Errno::ETIMEDOUT => e
+        rescue Timeout::Error, Errno::ECONNRESET, Errno::ETIMEDOUT
           raise ActionViewHelperError, "Erro ao conectar-se ao PagSeguro. Por favor, tente novamente."
         end
 

--- a/lib/offsite_payments/integrations/pay_fast.rb
+++ b/lib/offsite_payments/integrations/pay_fast.rb
@@ -212,7 +212,7 @@ module OffsitePayments #:nodoc:
 
         # The net amount credited to the receiver's account.
         def amount
-          Money.from_amount(BigDecimal.new(params['amount_net']), currency)
+          Money.from_amount(BigDecimal(params['amount_net']), currency)
         end
 
         # The name of the item being charged for.

--- a/lib/offsite_payments/integrations/payflow_link.rb
+++ b/lib/offsite_payments/integrations/payflow_link.rb
@@ -138,10 +138,6 @@ module OffsitePayments #:nodoc:
           nil
         end
 
-        def status
-          params['RESPMSG']
-        end
-
         # Id of this transaction (paypal number)
         def transaction_id
           params['PNREF']

--- a/lib/offsite_payments/integrations/paytm.rb
+++ b/lib/offsite_payments/integrations/paytm.rb
@@ -136,7 +136,7 @@ module OffsitePayments #:nodoc:
 
         # Order amount should be equal to gross
         def amount_ok?(order_amount)
-          BigDecimal.new(original_gross) == order_amount
+          BigDecimal(original_gross) == order_amount
         end
 
         # Status of transaction return from the Paytm. List of possible values:
@@ -245,7 +245,7 @@ module OffsitePayments #:nodoc:
         end
 
         def status(order_id, order_amount)
-          if @notification.invoice_ok?(order_id) && @notification.amount_ok?(BigDecimal.new(order_amount))
+          if @notification.invoice_ok?(order_id) && @notification.amount_ok?(BigDecimal(order_amount))
             @notification.status
           else
             'Mismatch'

--- a/lib/offsite_payments/integrations/payu_in.rb
+++ b/lib/offsite_payments/integrations/payu_in.rb
@@ -116,9 +116,9 @@ module OffsitePayments #:nodoc:
         end
 
         # Order amount should be equal to gross - discount
-        def amount_ok?( order_amount, order_discount = BigDecimal.new( '0.0' ) )
+        def amount_ok?( order_amount, order_discount = BigDecimal( '0.0' ) )
           parsed_discount = discount.nil? ? 0.to_d : discount.to_d
-          BigDecimal.new( original_gross ) == order_amount && parsed_discount == order_discount
+          BigDecimal( original_gross ) == order_amount && parsed_discount == order_discount
         end
 
         # Status of transaction return from the PayU. List of possible values:
@@ -258,7 +258,7 @@ module OffsitePayments #:nodoc:
         end
 
         def status( order_id, order_amount )
-          if @notification.invoice_ok?( order_id ) && @notification.amount_ok?( BigDecimal.new(order_amount) )
+          if @notification.invoice_ok?( order_id ) && @notification.amount_ok?( BigDecimal(order_amount) )
             @notification.status
           else
             'Mismatch'

--- a/lib/offsite_payments/integrations/platron.rb
+++ b/lib/offsite_payments/integrations/platron.rb
@@ -120,7 +120,7 @@ module OffsitePayments #:nodoc:
         end
 
         def amount
-          Money.from_amount(BigDecimal.new(params['pg_amount']), currency)
+          Money.from_amount(BigDecimal(params['pg_amount']), currency)
         end
 
         def secret

--- a/lib/offsite_payments/integrations/realex_offsite.rb
+++ b/lib/offsite_payments/integrations/realex_offsite.rb
@@ -424,10 +424,6 @@ module OffsitePayments #:nodoc:
           params['MESSAGE']
         end
 
-        def pasref
-          params['PASREF']
-        end
-
         def authcode
           params['AUTHCODE']
         end

--- a/lib/offsite_payments/integrations/sage_pay_form.rb
+++ b/lib/offsite_payments/integrations/sage_pay_form.rb
@@ -72,6 +72,7 @@ module OffsitePayments #:nodoc:
         attr_reader :identifier
 
         def initialize(order, account, options={})
+          @shipping_address_set = nil
           super
           @identifier = rand(0..99999).to_s.rjust(5, '0')
           add_field 'VendorTxCode', "#{order}-#{@identifier}"

--- a/lib/offsite_payments/integrations/web_pay.rb
+++ b/lib/offsite_payments/integrations/web_pay.rb
@@ -150,7 +150,7 @@ module OffsitePayments #:nodoc:
         end
 
         def amount
-          Money.from_amount(BigDecimal.new(gross), currency)
+          Money.from_amount(BigDecimal(gross), currency)
         end
 
         def item_id

--- a/lib/offsite_payments/integrations/webmoney.rb
+++ b/lib/offsite_payments/integrations/webmoney.rb
@@ -83,7 +83,7 @@ module OffsitePayments #:nodoc:
         end
 
         def amount
-          Money.from_amount(BigDecimal.new(gross), currency)
+          Money.from_amount(BigDecimal(gross), currency)
         end
 
         def key_present?

--- a/test/remote/remote_mollie_ideal_test.rb
+++ b/test/remote/remote_mollie_ideal_test.rb
@@ -13,7 +13,7 @@ class RemoteMollieIdealTest < Test::Unit::TestCase
 
   def test_create_payment_and_check_status
     create_response = MollieIdeal.create_payment(@api_key,
-      :amount => BigDecimal.new('123.45'),
+      :amount => BigDecimal('123.45'),
       :description => 'My order description',
       :redirectUrl => 'https://example.com/return',
       :method => 'ideal',

--- a/test/remote/remote_mollie_mistercash_test.rb
+++ b/test/remote/remote_mollie_mistercash_test.rb
@@ -9,7 +9,7 @@ class RemoteMollieMistercashTest < Test::Unit::TestCase
 
   def test_create_payment_and_check_status
     create_response = MollieMistercash.create_payment(@api_key,
-      :amount => BigDecimal.new('123.45'),
+      :amount => BigDecimal('123.45'),
       :description => 'My order description',
       :redirectUrl => 'https://example.com/return',
       :method => 'mistercash',

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -158,7 +158,7 @@ module OffsitePayments
 
     def load_fixtures
       [DEFAULT_CREDENTIALS, LOCAL_CREDENTIALS].inject({}) do |credentials, file_name|
-        if File.exists?(file_name)
+        if File.exist?(file_name)
           yaml_data = YAML.load(File.read(file_name))
           credentials.merge!(symbolize_keys(yaml_data))
         end

--- a/test/unit/integrations/citrus/citrus_notification_test.rb
+++ b/test/unit/integrations/citrus/citrus_notification_test.rb
@@ -14,7 +14,7 @@ class CitrusNotificationTest < Test::Unit::TestCase
     assert_equal "SUCCESS", @citrus.transaction_status
     assert_equal "INR", @citrus.currency
     assert_equal true, @citrus.invoice_ok?('ORD427')
-    assert_equal true, @citrus.amount_ok?(BigDecimal.new('10.00'))
+    assert_equal true, @citrus.amount_ok?(BigDecimal('10.00'))
     assert_equal "CASH_ON_DELIVERY", @citrus.paymentmode
     assert_equal "ORD427", @citrus.invoice
     assert_equal "807bb30a30a02b904f1434539f2eb07942ecb6f1", @citrus.checksum

--- a/test/unit/integrations/citrus/citrus_return_test.rb
+++ b/test/unit/integrations/citrus/citrus_return_test.rb
@@ -44,10 +44,10 @@ class CitrusReturnTest < Test::Unit::TestCase
     assert_equal "Completed", notification.status
     assert_equal "CTX1309180549472058821", notification.transaction_id
     assert_equal "SUCCESS", notification.transaction_status
-    assert_equal Money.from_amount(BigDecimal.new(10), "inr"), notification.amount
+    assert_equal Money.from_amount(BigDecimal(10), "inr"), notification.amount
     assert_equal "INR", notification.currency
     assert_equal true, notification.invoice_ok?('ORD427')
-    assert_equal true, notification.amount_ok?(BigDecimal.new('10.00'))
+    assert_equal true, notification.amount_ok?(BigDecimal('10.00'))
     assert_equal "CASH_ON_DELIVERY", notification.paymentmode
     assert_equal "ORD427", notification.invoice
     assert_equal "807bb30a30a02b904f1434539f2eb07942ecb6f1", notification.checksum

--- a/test/unit/integrations/easy_pay/easy_pay_notification_test.rb
+++ b/test/unit/integrations/easy_pay/easy_pay_notification_test.rb
@@ -14,7 +14,7 @@ class EasyPayNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.from_amount(BigDecimal.new('100.00'), 'BYR'), @easypay.amount
+    assert_equal Money.from_amount(BigDecimal('100.00'), 'BYR'), @easypay.amount
   end
 
   def test_credential2_required

--- a/test/unit/integrations/ipay88/ipay88_notification_test.rb
+++ b/test/unit/integrations/ipay88/ipay88_notification_test.rb
@@ -56,7 +56,6 @@ class Ipay88NotificationTest < Test::Unit::TestCase
   end
 
   def test_successful_acknowledge_on_cancellation
-    params = parameterize(payload)
     ipay = build_notification(http_raw_data(:payment_cancelled))
     assert ipay.acknowledge
   end

--- a/test/unit/integrations/klarna/klarna_helper_test.rb
+++ b/test/unit/integrations/klarna/klarna_helper_test.rb
@@ -106,7 +106,7 @@ class KlarnaHelperTest < Test::Unit::TestCase
   private
 
   def example_line_item(order_number = 1)
-    item = {
+    {
       :type => 'line item',
       :reference => "##{order_number}",
       :name => 'example item description',

--- a/test/unit/integrations/mollie/mollie_test.rb
+++ b/test/unit/integrations/mollie/mollie_test.rb
@@ -67,7 +67,7 @@ class MollieTest < Test::Unit::TestCase
 
   def test_post_request
     params =  {
-      :amount => BigDecimal.new('123.45'),
+      :amount => BigDecimal('123.45'),
       :description => 'My order description',
       :redirectUrl => 'https://example.com/return',
       :method => 'ideal',

--- a/test/unit/integrations/molpay/molpay_helper_test.rb
+++ b/test/unit/integrations/molpay/molpay_helper_test.rb
@@ -9,7 +9,7 @@ class MolpayHelperTest < Test::Unit::TestCase
     @helper = Molpay::Helper.new('order-5.00','molpaytech', :amount => 5.00, :currency => 'MYR', :credential2 => 'testcredential')
   end
 
- def test_basic_helper_fields
+  def test_basic_helper_fields
     assert_field "merchantid", "molpaytech"
     assert_field "amount", "5.00"
     assert_field "orderid", "order-5.00"

--- a/test/unit/integrations/pay_fast/pay_fast_notification_test.rb
+++ b/test/unit/integrations/pay_fast/pay_fast_notification_test.rb
@@ -19,7 +19,7 @@ class PayFastNotificationTest < Test::Unit::TestCase
   end
 
   def test_compositions
-    assert_equal Money.from_amount(BigDecimal.new('120.20'), 'ZAR'), @pay_fast.amount
+    assert_equal Money.from_amount(BigDecimal('120.20'), 'ZAR'), @pay_fast.amount
   end
 
   def test_acknowledgement

--- a/test/unit/integrations/payflow_link/payflow_link_helper_test.rb
+++ b/test/unit/integrations/payflow_link/payflow_link_helper_test.rb
@@ -17,11 +17,10 @@ class PayflowLinkHelperTest < Test::Unit::TestCase
   end
 
   def teardown
-    $KCODE = @original_kcode if @original_kcode
+    $KCODE = @original_kcode if defined?(@original_kcode)
   end
 
   def test_basic_helper_fields
-
     @helper.expects(:ssl_post).with { |url, data|
       params = parse_params(data)
 

--- a/test/unit/integrations/paypal_payments_advanced/paypal_payments_advanced_helper_test.rb
+++ b/test/unit/integrations/paypal_payments_advanced/paypal_payments_advanced_helper_test.rb
@@ -11,7 +11,7 @@ class PaypalPaymentsAdvancedHelperTest < Test::Unit::TestCase
   end
 
   def teardown
-    $KCODE = @original_kcode if @original_kcode
+    $KCODE = @original_kcode if defined? @original_kcode
   end
 
   def test_basic_helper_fields

--- a/test/unit/integrations/paytm/paytm_notification_test.rb
+++ b/test/unit/integrations/paytm/paytm_notification_test.rb
@@ -16,7 +16,7 @@ class PaytmNotificationTest < Test::Unit::TestCase
     assert_equal '10.00', @paytm.gross
     assert_equal 'INR', @paytm.currency
     assert_equal true, @paytm.invoice_ok?('100PT012')
-    assert_equal true, @paytm.amount_ok?(BigDecimal.new('10.00'))
+    assert_equal true, @paytm.amount_ok?(BigDecimal('10.00'))
     assert_equal 'CC', @paytm.type
     assert_equal '100PT012', @paytm.invoice
     assert_equal 'WorldP64425807474247', @paytm.account

--- a/test/unit/integrations/paytm/paytm_return_test.rb
+++ b/test/unit/integrations/paytm/paytm_return_test.rb
@@ -32,7 +32,7 @@ class PaytmReturnTest < Test::Unit::TestCase
     assert notification.complete?
     assert_equal 'Completed', notification.status
     assert notification.invoice_ok?('100PT012')
-    assert notification.amount_ok?(BigDecimal.new('10.00'))
+    assert notification.amount_ok?(BigDecimal('10.00'))
     assert_equal 'TXN_SUCCESS', notification.transaction_status
     assert_equal '494157', @paytm.notification.transaction_id
     assert_equal 'CC', @paytm.notification.type

--- a/test/unit/integrations/payu_in/payu_in_notification_test.rb
+++ b/test/unit/integrations/payu_in/payu_in_notification_test.rb
@@ -16,7 +16,7 @@ class PayuInNotificationTest < Test::Unit::TestCase
     assert_equal "Product Info", @payu.product_info
     assert_equal "INR", @payu.currency
     assert_equal true, @payu.invoice_ok?('4ba4afe87f7e73468f2a')
-    assert_equal true, @payu.amount_ok?(BigDecimal.new('10.00'),BigDecimal.new('0.00'))
+    assert_equal true, @payu.amount_ok?(BigDecimal('10.00'),BigDecimal('0.00'))
     assert_equal "CC", @payu.type
     assert_equal "4ba4afe87f7e73468f2a", @payu.invoice
     assert_equal "merchant_id", @payu.account

--- a/test/unit/integrations/payu_in/payu_in_return_test.rb
+++ b/test/unit/integrations/payu_in/payu_in_return_test.rb
@@ -41,7 +41,7 @@ class PayuInReturnTest < Test::Unit::TestCase
     assert notification.complete?
     assert_equal 'Completed', notification.status
     assert notification.invoice_ok?('4ba4afe87f7e73468f2a')
-    assert notification.amount_ok?(BigDecimal.new('10.00'),BigDecimal.new('0.00'))
+    assert notification.amount_ok?(BigDecimal('10.00'),BigDecimal('0.00'))
     assert_equal "success", notification.transaction_status
     assert_equal '403993715508030204', @payu.notification.transaction_id
     assert_equal 'CC', @payu.notification.type

--- a/test/unit/integrations/payu_in_paisa/payu_in_paisa_notification_test.rb
+++ b/test/unit/integrations/payu_in_paisa/payu_in_paisa_notification_test.rb
@@ -16,7 +16,7 @@ class PayuInPaisaNotificationTest < Test::Unit::TestCase
     assert_equal "Product Info", @payu.product_info
     assert_equal "INR", @payu.currency
     assert_equal true, @payu.invoice_ok?('4ba4afe87f7e73468f2a')
-    assert_equal true, @payu.amount_ok?(BigDecimal.new('10.00'),BigDecimal.new('0.00'))
+    assert_equal true, @payu.amount_ok?(BigDecimal('10.00'),BigDecimal('0.00'))
     assert_equal "CC", @payu.type
     assert_equal "4ba4afe87f7e73468f2a", @payu.invoice
     assert_equal "merchant_id", @payu.account

--- a/test/unit/integrations/payu_in_paisa/payu_in_paisa_return_test.rb
+++ b/test/unit/integrations/payu_in_paisa/payu_in_paisa_return_test.rb
@@ -46,7 +46,7 @@ class PayuInPaisaReturnTest < Test::Unit::TestCase
     assert notification.complete?
     assert_equal 'Completed', notification.status
     assert notification.invoice_ok?('4ba4afe87f7e73468f2a')
-    assert notification.amount_ok?(BigDecimal.new('10.00'), BigDecimal.new('0.00'))
+    assert notification.amount_ok?(BigDecimal('10.00'), BigDecimal('0.00'))
     assert_equal "success", notification.transaction_status
     assert_equal '403993715508030204', @payu.notification.transaction_id
     assert_equal 'CC', @payu.notification.type

--- a/test/unit/integrations/sage_pay_form/sage_pay_form_helper_test.rb
+++ b/test/unit/integrations/sage_pay_form/sage_pay_form_helper_test.rb
@@ -28,7 +28,7 @@ class SagePayFormHelperTest < Test::Unit::TestCase
   end
 
   def test_identifier_should_only_contain_digits
-    assert_match /^[0-9]*$/, @helper.identifier
+    assert_match(/^[0-9]*$/, @helper.identifier)
   end
 
   def test_customer_fields
@@ -204,7 +204,7 @@ class SagePayFormHelperTest < Test::Unit::TestCase
 
   def test_crypt_field_is_hex
     crypt = @helper.form_fields['Crypt']
-    assert_match /^@[A-F0-9]+$/, crypt
+    assert_match(/^@[A-F0-9]+$/, crypt)
   end
 
   def test_crypt_field_is_uniq


### PR DESCRIPTION
In 2.7. `BigDecimal.new` is gone, and only `BigDecimal` remains.

cc @pi3r @Shopify/rails @DazWorrall @wvanbergen 