### PR TITLE
FIX build failed / Change to use `String#start_with?` instead of `String#starts_with?`.

### DIFF
--- a/lib/offsite_payments/integrations/paxum.rb
+++ b/lib/offsite_payments/integrations/paxum.rb
@@ -34,9 +34,9 @@ module OffsitePayments #:nodoc:
 
       module Common
         def generate_signature_string
-          @raw_post.slice!(0) if @raw_post.starts_with?("&")
+          @raw_post.slice!(0) if @raw_post.start_with?("&")
           @raw_post = CGI.unescape(@raw_post)
-          @raw_post = "&#{@raw_post}" unless @raw_post.starts_with?("&")
+          @raw_post = "&#{@raw_post}" unless @raw_post.start_with?("&")
           arr = @raw_post.split('&')
           arr.delete(arr.last)
           data = arr.join('&')


### PR DESCRIPTION
In Rails edge, deprecate `starts_with?` and `ends_with?` for String core extensions.
Ref https://github.com/rails/rails/pull/39152.

So it seems pull requests are failed since this summer. (#344 and later issues)

Prior to this pull request, I confirmed this commit on my forked repository.
https://github.com/akiko-pusu/offsite_payments/pull/2