### PR TITLE
[Proposal] Update IPNs URL

### DIFF
--- a/lib/offsite_payments/integrations/paxum.rb
+++ b/lib/offsite_payments/integrations/paxum.rb
@@ -34,9 +34,9 @@ module OffsitePayments #:nodoc:
 
       module Common
         def generate_signature_string
-          @raw_post.slice!(0) if @raw_post.starts_with?("&")
+          @raw_post.slice!(0) if @raw_post.start_with?("&")
           @raw_post = CGI.unescape(@raw_post)
-          @raw_post = "&#{@raw_post}" unless @raw_post.starts_with?("&")
+          @raw_post = "&#{@raw_post}" unless @raw_post.start_with?("&")
           arr = @raw_post.split('&')
           arr.delete(arr.last)
           data = arr.join('&')

--- a/lib/offsite_payments/integrations/paypal.rb
+++ b/lib/offsite_payments/integrations/paypal.rb
@@ -3,11 +3,13 @@ module OffsitePayments #:nodoc:
     module Paypal
       # Overwrite this if you want to change the Paypal test url
       mattr_accessor :test_url
-      self.test_url = 'https://www.sandbox.paypal.com/cgi-bin/webscr'
+      self.test_url = 'https://ipnpb.sandbox.paypal.com/cgi-bin/webscr'
 
       # Overwrite this if you want to change the Paypal production url
+      # NOTE: https://www.paypal.com/ returns dynamic IP addresse.
+      # Please refer to <https://www.paypal.com/us/smarthelp/article/what-are-the-ip-addresses-for-live-paypal-servers-ts1056>
       mattr_accessor :production_url
-      self.production_url = 'https://www.paypal.com/cgi-bin/webscr'
+      self.production_url = 'https://ipnpb.paypal.com/cgi-bin/webscr'
 
       def self.service_url
         mode = OffsitePayments.mode

--- a/test/unit/integrations/paypal/paypal_module_test.rb
+++ b/test/unit/integrations/paypal/paypal_module_test.rb
@@ -9,12 +9,12 @@ class PaypalModuleTest < Test::Unit::TestCase
 
   def test_test_mode
     OffsitePayments.mode = :test
-    assert_equal 'https://www.sandbox.paypal.com/cgi-bin/webscr', Paypal.service_url
+    assert_equal 'https://ipnpb.sandbox.paypal.com/cgi-bin/webscr', Paypal.service_url
   end
 
   def test_production_mode
     OffsitePayments.mode = :production
-    assert_equal 'https://www.paypal.com/cgi-bin/webscr', Paypal.service_url
+    assert_equal 'https://ipnpb.paypal.com/cgi-bin/webscr', Paypal.service_url
   ensure
     OffsitePayments.mode = :test
   end


### PR DESCRIPTION
Thanks for all!
This pull request is not a bug fix, but a proposal.

## Reason

Now Paypal recommends the use of new endpoints based on 'ipnpb.paypal.com'.

Ref: 

- https://developer.paypal.com/docs/api-basics/notifications/ipn/IPNImplementation/
- https://developer.paypal.com/docs/api-basics/notifications/ipn/IPNSimulator/
- https://www.paypal.com/us/smarthelp/article/what-are-the-ip-addresses-for-live-paypal-servers-ts1056

## What happens in this situation?

We can still use the URL ``https://www.sandbox.paypal.com/cgi-bin/webscr`` and ``https://www.paypal.com/cgi-bin/webscr`` without any difference in terms of API features.

But following the [document](https://www.paypal.com/us/smarthelp/article/what-are-the-ip-addresses-for-live-paypal-servers-ts1056) that I wrote above,  ``www.paypal.com`` returns the response under the dynamic IP address.
If some requirements exist such as restriction for the source/destination IP address, ''ipnpb.paypal.com'' based URL is better.

Of course, we can change the URL by ourselves by overwriting the variable like this:

```ruby
# production_url is customizable because of "mattr_accessor" statement.
OffsitePayments::Integrations::Paypal.production_url = 'https://ipnpb.paypal.com/cgi-bin/webscr'
```

## Other proposals

If this PR is not acceptable, I think updating README to introduce how to customize the URL like above.

## NOTE:

Before submitting this pull request, I posted the one to fix the CI failure.
I wish either one would be of help.