### PR TITLE
Lock Gemfile-shopify to money 0.14.x

### DIFF
--- a/gemfiles/Gemfile.shopify
+++ b/gemfiles/Gemfile.shopify
@@ -10,4 +10,4 @@ group :remote_test do
 end
 
 gem 'actionpack', '~> 6.0.0'
-gem 'shopify-money',  require: 'money'
+gem 'shopify-money', '~> 0.14.0', require: 'money'


### PR DESCRIPTION
The `Gemfile.shopify` file doesn't specify a version of money to use. I'm not entirely sure _why_ that's the case, but it seems like an unnecessary risk to me that can just lead to headaches.

A particular headache I'm currently experiencing (and that's prompting me to lock this) is that Money 0.15 was just released (https://github.com/Shopify/money) and [several tests began to fail](https://github.com/activemerchant/offsite_payments/runs/1736831871) because of that.

Let's keep the minor version locked for now to prevent breakages introduced by functionality changes.

We can bump the money gem to 0.15 in a follow up PR, for now we need to create a release for a fix for Gestpay https://github.com/activemerchant/offsite_payments/pull/352