### PR TITLE
Bump money gem

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -26,10 +26,12 @@ jobs:
           - gemfiles/Gemfile.shopify
           - gemfiles/Gemfile.rails-edge
         exclude:
-          - version: 2.5
-            gemfile: gemfiles/Gemfile.rails-edge
           - version: 2.6
             gemfile: gemfiles/Gemfile.rails-edge
+          - version: 2.5
+            gemfile: gemfiles/Gemfile.rails-edge
+          - version: 2.5
+            gemfile: gemfiles/Gemfile.shopify
     steps:
       - uses: actions/checkout@v2
 

--- a/gemfiles/Gemfile.shopify
+++ b/gemfiles/Gemfile.shopify
@@ -10,4 +10,4 @@ group :remote_test do
 end
 
 gem 'actionpack', '~> 6.0.0'
-gem 'shopify-money', '~> 0.14.0', require: 'money'
+gem 'shopify-money', '~> 0.15.0', require: 'money'

--- a/lib/offsite_payments/helper.rb
+++ b/lib/offsite_payments/helper.rb
@@ -1,5 +1,13 @@
 module OffsitePayments #:nodoc:
+  module MoneyCompatibility
+    def to_cents(money)
+      money.try(:cents) || money.try(:subunits) || money
+    end
+  end
+
   class Helper #:nodoc:
+    include MoneyCompatibility
+
     attr_reader :fields
     class_attribute :service_url
     class_attribute :mappings

--- a/lib/offsite_payments/integrations/direc_pay.rb
+++ b/lib/offsite_payments/integrations/direc_pay.rb
@@ -97,7 +97,7 @@ module OffsitePayments #:nodoc:
 
         # Need to format the amount to have 2 decimal places
         def amount=(money)
-          cents = money.respond_to?(:cents) ? money.cents : money
+          cents = to_cents(money)
           raise ArgumentError, "amount must be a Money object or an integer" if money.is_a?(String)
           raise ActionViewHelperError, "amount must be greater than $0.00" if cents.to_i <= 0
 

--- a/lib/offsite_payments/integrations/directebanking.rb
+++ b/lib/offsite_payments/integrations/directebanking.rb
@@ -89,7 +89,7 @@ module OffsitePayments #:nodoc:
 
         # Need to format the amount to have 2 decimal places
         def amount=(money)
-          cents = money.respond_to?(:cents) ? money.cents : money
+          cents = to_cents(money)
           raise ArgumentError, "amount must be a Money object or an integer" if money.is_a?(String)
           raise ActionViewHelperError, "amount must be greater than $0.00" if cents.to_i <= 0
 

--- a/lib/offsite_payments/integrations/hi_trust.rb
+++ b/lib/offsite_payments/integrations/hi_trust.rb
@@ -43,7 +43,7 @@ module OffsitePayments #:nodoc:
         mapping :amount, 'amount'
 
         def amount=(money)
-          cents = money.respond_to?(:cents) ? money.cents : money
+          cents = to_cents(money)
           raise ArgumentError, "amount must be a Money object or an integer" if money.is_a?(String)
           raise ActionViewHelperError, "amount must be greater than $0.00" if cents.to_i <= 0
 

--- a/lib/offsite_payments/integrations/ipay88.rb
+++ b/lib/offsite_payments/integrations/ipay88.rb
@@ -66,7 +66,7 @@ module OffsitePayments #:nodoc:
         end
 
         def amount=(money)
-          @amount_in_cents = money.respond_to?(:cents) ? money.cents : money
+          @amount_in_cents = to_cents(money)
           raise ArgumentError, "amount must be a Money object or an integer" if money.is_a?(String)
           raise ActionViewHelperError, "amount must be greater than $0.00" if @amount_in_cents.to_i <= 0
 

--- a/lib/offsite_payments/integrations/nochex.rb
+++ b/lib/offsite_payments/integrations/nochex.rb
@@ -94,7 +94,7 @@ module OffsitePayments #:nodoc:
 
         # Need to format the amount to have 2 decimal places
         def amount=(money)
-          cents = money.respond_to?(:cents) ? money.cents : money
+          cents = to_cents(money)
           raise ArgumentError, "amount must be a Money object or an integer" if money.is_a?(String)
           raise ActionViewHelperError, "amount must be greater than $0.00" if cents.to_i <= 0
 

--- a/test/unit/integrations/direc_pay/direc_pay_helper_test.rb
+++ b/test/unit/integrations/direc_pay/direc_pay_helper_test.rb
@@ -7,6 +7,11 @@ class DirecPayHelperTest < Test::Unit::TestCase
     @helper = DirecPay::Helper.new('#1234', 'account id', :amount => 500, :currency => 'INR')
   end
 
+  def test_money_amount_assigment
+    @helper.amount = Money.from_amount(1.20)
+    assert_field 'Amount', '1.20'
+  end
+
   def test_basic_helper_fields
     assert_field 'MID', 'account id'
     assert_field 'Merchant Order No', '#1234'

--- a/test/unit/integrations/directebanking/directebanking_helper_test.rb
+++ b/test/unit/integrations/directebanking/directebanking_helper_test.rb
@@ -9,6 +9,11 @@ class DirectebankingHelperTest < Test::Unit::TestCase
     @helper.return_url "https://localhost:8080/directebanking"
   end
 
+  def test_money_amount_assigment
+    @helper.amount = Money.from_amount(1.20)
+    assert_field 'amount', '1.20'
+  end
+
   def test_urls
     @helper.cancel_return_url "https://localhost:8080/directebanking/cancel"
     @helper.notify_url "https://localhost:8080/directebanking/notify"

--- a/test/unit/integrations/hi_trust/hi_trust_helper_test.rb
+++ b/test/unit/integrations/hi_trust/hi_trust_helper_test.rb
@@ -7,6 +7,11 @@ class HiTrustHelperTest < Test::Unit::TestCase
     @helper = HiTrust::Helper.new('order-500','cody@example.com', :amount => 500, :currency => 'USD')
   end
 
+  def test_money_amount_to_cents
+    @helper.amount = Money.from_amount(1.20)
+    assert_field 'amount', '120'
+  end
+
   def test_basic_helper_fields
     assert_field 'storeid', 'cody@example.com'
     assert_field 'amount', '500'

--- a/test/unit/integrations/nochex/nochex_helper_test.rb
+++ b/test/unit/integrations/nochex/nochex_helper_test.rb
@@ -7,6 +7,11 @@ class NochexHelperTest < Test::Unit::TestCase
     @helper = Nochex::Helper.new('order-500','cody@example.com', :amount => 500, :currency => 'GBP')
   end
 
+  def test_money_amount_assigment
+    @helper.amount = Money.from_amount(1.20)
+    assert_field 'amount', '1.20'
+  end
+
   def test_basic_helper_fields
     assert_field 'email', 'cody@example.com'
 


### PR DESCRIPTION
For solving [issue](https://shopify-money.atlassian.net/browse/PPI-18?atlOrigin=eyJpIjoiYThjNzAwN2M0MzNmNGY2MDg1NjZjNTZhOGFhMzBkZDEiLCJwIjoiaiJ9). Bump the version of gem `shopify-money` and make the integrations compatible for both `shopify-money` and `money` gem.

The reason why this change is needed. https://github.com/Shopify/money/pull/221 this makes [shopify-money](https://github.com/Shopify/money/pull/221) gem and [money](https://github.com/RubyMoney/money) gem incompatible, and some integrations are still rely on the money object.