### PR TITLE
Disable Rails Edge for Ruby 2.5 and 2.6

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -25,12 +25,14 @@ jobs:
           - gemfiles/Gemfile.latest-release
           - gemfiles/Gemfile.shopify
           - gemfiles/Gemfile.rails-edge
-        # exclude:
-        #   - version: 2.7
-        #     gemfile: <Gemfile> to exclude for Ruby Version above
+        exclude:
+          - version: 2.5
+            gemfile: gemfiles/Gemfile.rails-edge
+          - version: 2.6
+            gemfile: gemfiles/Gemfile.rails-edge
     steps:
       - uses: actions/checkout@v2
-      
+
       - name: Set up Ruby ${{ matrix.version }}
         uses: ruby/setup-ruby@v1
         with:
@@ -39,7 +41,3 @@ jobs:
 
       - name: Test
         run: bundle exec rake test
-
-      # - name: Lint
-      #   run: bundle exec rubocop --fail-fast
-      #   working-directory: ./gems/offsite_payments


### PR DESCRIPTION
Since Rails Edge only supports Ruby 2.7 according to the [edge documentation](https://edgeguides.rubyonrails.org/getting_started.html#installing-ruby), we're disabling `Gemfile.rails-edge` for Ruby 2.5 and 2.6.