### PR TITLE
Update with new urls for Hosted Payment Page

### DIFF
--- a/lib/offsite_payments/integrations/realex_offsite.rb
+++ b/lib/offsite_payments/integrations/realex_offsite.rb
@@ -3,8 +3,8 @@ module OffsitePayments #:nodoc:
     module RealexOffsite
       mattr_accessor :production_url
       mattr_accessor :test_url
-      self.production_url = 'https://api.realexpayments.com/epage-remote.cgi'
-      self.test_url       = 'https://api.sandbox.realexpayments.com/epage-remote.cgi'
+      self.production_url = 'https://pay.realexpayments.com/pay'
+      self.test_url       = 'https://pay.sandbox.realexpayments.com/pay'
 
       def self.helper(order, account, options={})
         Helper.new(order, account, options)


### PR DESCRIPTION
Reference:  https://developer.globalpay.com/hpp/hpp-reference