### PR TITLE
Enable frozen_string_literals

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 gemspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,9 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mimemagic (0.3.3)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.1)
     mini_portile2 (2.5.0)
     minitest (5.11.3)
@@ -193,4 +195,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.1.4
+   2.2.22

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $:.unshift File.expand_path('../lib', __FILE__)
 require 'offsite_payments/version'
 

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 require "offsite_payments"

--- a/generators/integration_generator.rb
+++ b/generators/integration_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "thor/group"
 
 class IntegrationGenerator < Thor::Group

--- a/lib/offsite_payments.rb
+++ b/lib/offsite_payments.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 fail %q{
   Money is required for offsite_payments to work, please refer to https://github.com/activemerchant/offsite_payments#money-gem-dependency
 } unless defined?(Money)

--- a/lib/offsite_payments/action_view_helper.rb
+++ b/lib/offsite_payments/action_view_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'action_pack'
 
 module OffsitePayments #:nodoc:
@@ -63,7 +65,7 @@ module OffsitePayments #:nodoc:
       end
 
       result << '</form>'
-      result= result.join("\n")
+      result = result.join("\n")
 
       concat(result.respond_to?(:html_safe) ? result.html_safe : result)
       nil

--- a/lib/offsite_payments/helper.rb
+++ b/lib/offsite_payments/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module MoneyCompatibility
     def to_cents(money)

--- a/lib/offsite_payments/integrations.rb
+++ b/lib/offsite_payments/integrations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments
   module Integrations
     Dir[File.dirname(__FILE__) + '/integrations/*.rb'].each do |f|

--- a/lib/offsite_payments/integrations/a1agregator.rb
+++ b/lib/offsite_payments/integrations/a1agregator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module A1agregator

--- a/lib/offsite_payments/integrations/authorize_net_sim.rb
+++ b/lib/offsite_payments/integrations/authorize_net_sim.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module AuthorizeNetSim

--- a/lib/offsite_payments/integrations/bit_pay.rb
+++ b/lib/offsite_payments/integrations/bit_pay.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module BitPay

--- a/lib/offsite_payments/integrations/bogus.rb
+++ b/lib/offsite_payments/integrations/bogus.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Bogus

--- a/lib/offsite_payments/integrations/checkout_finland.rb
+++ b/lib/offsite_payments/integrations/checkout_finland.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module CheckoutFinland

--- a/lib/offsite_payments/integrations/chronopay.rb
+++ b/lib/offsite_payments/integrations/chronopay.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Chronopay

--- a/lib/offsite_payments/integrations/citrus.rb
+++ b/lib/offsite_payments/integrations/citrus.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments
   module Integrations
     module Citrus

--- a/lib/offsite_payments/integrations/coinbase.rb
+++ b/lib/offsite_payments/integrations/coinbase.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Coinbase

--- a/lib/offsite_payments/integrations/direc_pay.rb
+++ b/lib/offsite_payments/integrations/direc_pay.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module DirecPay

--- a/lib/offsite_payments/integrations/directebanking.rb
+++ b/lib/offsite_payments/integrations/directebanking.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Directebanking

--- a/lib/offsite_payments/integrations/doku.rb
+++ b/lib/offsite_payments/integrations/doku.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Doku

--- a/lib/offsite_payments/integrations/dotpay.rb
+++ b/lib/offsite_payments/integrations/dotpay.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Dotpay

--- a/lib/offsite_payments/integrations/dwolla.rb
+++ b/lib/offsite_payments/integrations/dwolla.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Dwolla

--- a/lib/offsite_payments/integrations/e_payment_plans.rb
+++ b/lib/offsite_payments/integrations/e_payment_plans.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module EPaymentPlans

--- a/lib/offsite_payments/integrations/easy_pay.rb
+++ b/lib/offsite_payments/integrations/easy_pay.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     # Documentation: https://ssl.easypay.by/light/

--- a/lib/offsite_payments/integrations/epay.rb
+++ b/lib/offsite_payments/integrations/epay.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Epay

--- a/lib/offsite_payments/integrations/first_data.rb
+++ b/lib/offsite_payments/integrations/first_data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module FirstData

--- a/lib/offsite_payments/integrations/gestpay.rb
+++ b/lib/offsite_payments/integrations/gestpay.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # With help from Giovanni Intini and his code for RGestPay - http://medlar.it/it/progetti/rgestpay
 
 module OffsitePayments #:nodoc:

--- a/lib/offsite_payments/integrations/hi_trust.rb
+++ b/lib/offsite_payments/integrations/hi_trust.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module HiTrust

--- a/lib/offsite_payments/integrations/ipay88.rb
+++ b/lib/offsite_payments/integrations/ipay88.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Ipay88

--- a/lib/offsite_payments/integrations/klarna.rb
+++ b/lib/offsite_payments/integrations/klarna.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Klarna
@@ -17,12 +19,9 @@ module OffsitePayments #:nodoc:
       def self.cart_items_payload(fields, cart_items)
         check_required_fields!(fields)
 
-        payload = ""
-        REQUIRED_FIELDS.sort.each do |field|
-           payload << fields[field].to_s
-        end
-
-        payload
+        REQUIRED_FIELDS.sort.map do |field|
+           fields[field].to_s
+        end.join
       end
 
       def self.sign(fields, cart_items, shared_secret)

--- a/lib/offsite_payments/integrations/liqpay.rb
+++ b/lib/offsite_payments/integrations/liqpay.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     # Documentation: https://www.liqpay.com/?do=pages&p=cnb10

--- a/lib/offsite_payments/integrations/maksuturva.rb
+++ b/lib/offsite_payments/integrations/maksuturva.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     # USAGE:

--- a/lib/offsite_payments/integrations/mollie.rb
+++ b/lib/offsite_payments/integrations/mollie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Mollie

--- a/lib/offsite_payments/integrations/mollie_ideal.rb
+++ b/lib/offsite_payments/integrations/mollie_ideal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module MollieIdeal

--- a/lib/offsite_payments/integrations/mollie_mistercash.rb
+++ b/lib/offsite_payments/integrations/mollie_mistercash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module MollieMistercash

--- a/lib/offsite_payments/integrations/molpay.rb
+++ b/lib/offsite_payments/integrations/molpay.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Molpay

--- a/lib/offsite_payments/integrations/moneybookers.rb
+++ b/lib/offsite_payments/integrations/moneybookers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Moneybookers

--- a/lib/offsite_payments/integrations/nochex.rb
+++ b/lib/offsite_payments/integrations/nochex.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     # To start with Nochex, follow the instructions for installing

--- a/lib/offsite_payments/integrations/pag_seguro.rb
+++ b/lib/offsite_payments/integrations/pag_seguro.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
@@ -117,10 +117,10 @@ module OffsitePayments #:nodoc:
 
         def area_code_and_number(phone)
           return if phone.nil?
-          phone.gsub!(/[^\d]/, '')
+          clean_phone = phone.gsub(/[^\d]/, '')
 
-          ddd    = phone.slice(0..1)
-          number = phone.slice(2..12)
+          ddd    = clean_phone.slice(0..1)
+          number = clean_phone.slice(2..12)
 
           [ddd, number]
         end

--- a/lib/offsite_payments/integrations/paxum.rb
+++ b/lib/offsite_payments/integrations/paxum.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     # Documentation:
@@ -89,8 +91,7 @@ module OffsitePayments #:nodoc:
 
         def initialize(post, options = {})
           @raw_post = post.dup
-          post.slice!(0)
-          super
+          super(post.slice(1..-1), options)
         end
 
         def self.recognizes?(params)

--- a/lib/offsite_payments/integrations/pay_fast.rb
+++ b/lib/offsite_payments/integrations/pay_fast.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     # Documentation:

--- a/lib/offsite_payments/integrations/paydollar.rb
+++ b/lib/offsite_payments/integrations/paydollar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Paydollar

--- a/lib/offsite_payments/integrations/payflow_link.rb
+++ b/lib/offsite_payments/integrations/payflow_link.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module PayflowLink

--- a/lib/offsite_payments/integrations/paypal.rb
+++ b/lib/offsite_payments/integrations/paypal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Paypal
@@ -93,10 +95,8 @@ module OffsitePayments #:nodoc:
           add_field(mappings[:shipping_address][:country], country_code)
 
           if params.has_key?(:phone)
-            phone = params.delete(:phone).to_s
-
             # Wipe all non digits
-            phone.gsub!(/\D+/, '')
+            phone = params.delete(:phone).to_s.gsub(/\D+/, '')
 
             if ['US', 'CA'].include?(country_code) && phone =~ /(\d{3})(\d{3})(\d{4})$/
               add_field('night_phone_a', $1)

--- a/lib/offsite_payments/integrations/paypal_payments_advanced.rb
+++ b/lib/offsite_payments/integrations/paypal_payments_advanced.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments
   module Integrations
     module PaypalPaymentsAdvanced

--- a/lib/offsite_payments/integrations/paysbuy.rb
+++ b/lib/offsite_payments/integrations/paysbuy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Paysbuy

--- a/lib/offsite_payments/integrations/paytm.rb
+++ b/lib/offsite_payments/integrations/paytm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Paytm

--- a/lib/offsite_payments/integrations/payu_in.rb
+++ b/lib/offsite_payments/integrations/payu_in.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module PayuIn

--- a/lib/offsite_payments/integrations/payu_in_paisa.rb
+++ b/lib/offsite_payments/integrations/payu_in_paisa.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments
   module Integrations
     module PayuInPaisa

--- a/lib/offsite_payments/integrations/platron.rb
+++ b/lib/offsite_payments/integrations/platron.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'builder'
 
 module OffsitePayments #:nodoc:
@@ -137,7 +139,7 @@ module OffsitePayments #:nodoc:
 
         def success_response(path,secret)
           salt = rand(36**15).to_s(36)
-          xml = ""
+          xml = +""
           doc = Builder::XmlMarkup.new(:target => xml)
           sign = Platron.generate_signature({:pg_status => 'ok', :pg_salt => salt}, path, secret)
           doc.response do

--- a/lib/offsite_payments/integrations/pxpay.rb
+++ b/lib/offsite_payments/integrations/pxpay.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rexml/document'
 
 module OffsitePayments #:nodoc:

--- a/lib/offsite_payments/integrations/quickpay.rb
+++ b/lib/offsite_payments/integrations/quickpay.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Quickpay

--- a/lib/offsite_payments/integrations/quickpay_v10.rb
+++ b/lib/offsite_payments/integrations/quickpay_v10.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 
 module OffsitePayments #:nodoc:

--- a/lib/offsite_payments/integrations/rbkmoney.rb
+++ b/lib/offsite_payments/integrations/rbkmoney.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Rbkmoney

--- a/lib/offsite_payments/integrations/realex_offsite.rb
+++ b/lib/offsite_payments/integrations/realex_offsite.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module RealexOffsite

--- a/lib/offsite_payments/integrations/robokassa.rb
+++ b/lib/offsite_payments/integrations/robokassa.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     # Documentation: http://robokassa.ru/Doc/En/Interface.aspx

--- a/lib/offsite_payments/integrations/sage_pay_form.rb
+++ b/lib/offsite_payments/integrations/sage_pay_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module SagePayForm

--- a/lib/offsite_payments/integrations/two_checkout.rb
+++ b/lib/offsite_payments/integrations/two_checkout.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module TwoCheckout

--- a/lib/offsite_payments/integrations/universal.rb
+++ b/lib/offsite_payments/integrations/universal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Universal

--- a/lib/offsite_payments/integrations/valitor.rb
+++ b/lib/offsite_payments/integrations/valitor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     module Valitor

--- a/lib/offsite_payments/integrations/verkkomaksut.rb
+++ b/lib/offsite_payments/integrations/verkkomaksut.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     # Usage, see the blog post here: http://blog.kiskolabs.com/post/22374612968/understanding-active-merchant-integrations and E1 API documentation here: http://docs.verkkomaksut.fi/

--- a/lib/offsite_payments/integrations/web_pay.rb
+++ b/lib/offsite_payments/integrations/web_pay.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     # Documentation: You will get it after registration steps here:

--- a/lib/offsite_payments/integrations/webmoney.rb
+++ b/lib/offsite_payments/integrations/webmoney.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     # Documentation:

--- a/lib/offsite_payments/integrations/wirecard_checkout_page.rb
+++ b/lib/offsite_payments/integrations/wirecard_checkout_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:
     # Shop System Plugins - Terms of use

--- a/lib/offsite_payments/integrations/world_pay.rb
+++ b/lib/offsite_payments/integrations/world_pay.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ipaddr'
 module OffsitePayments #:nodoc:
   module Integrations #:nodoc:

--- a/lib/offsite_payments/notification.rb
+++ b/lib/offsite_payments/notification.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   class Notification
     attr_accessor :params

--- a/lib/offsite_payments/return.rb
+++ b/lib/offsite_payments/return.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments #:nodoc:
   class Return
     attr_accessor :params

--- a/lib/offsite_payments/version.rb
+++ b/lib/offsite_payments/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OffsitePayments
   VERSION = "2.7.28"
 end

--- a/offsite_payments.gemspec
+++ b/offsite_payments.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $:.push File.expand_path("../lib", __FILE__)
 require 'offsite_payments/version'
 

--- a/script/generate
+++ b/script/generate
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require "rubygems"
 require "thor"
 

--- a/test/remote/remote_bit_pay_test.rb
+++ b/test/remote/remote_bit_pay_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'remote_test_helper'
 

--- a/test/remote/remote_checkout_finland_test.rb
+++ b/test/remote/remote_checkout_finland_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'remote_test_helper'
 

--- a/test/remote/remote_direc_pay_test.rb
+++ b/test/remote/remote_direc_pay_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RemoteDirecPayTest < Test::Unit::TestCase

--- a/test/remote/remote_doku_test.rb
+++ b/test/remote/remote_doku_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RemoteDokuTest < Test::Unit::TestCase

--- a/test/remote/remote_gestpay_test.rb
+++ b/test/remote/remote_gestpay_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RemoteGestpayTest < Test::Unit::TestCase

--- a/test/remote/remote_mollie_ideal_test.rb
+++ b/test/remote/remote_mollie_ideal_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RemoteMollieIdealTest < Test::Unit::TestCase

--- a/test/remote/remote_mollie_mistercash_test.rb
+++ b/test/remote/remote_mollie_mistercash_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RemoteMollieMistercashTest < Test::Unit::TestCase

--- a/test/remote/remote_molpay_test.rb
+++ b/test/remote/remote_molpay_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'remote_test_helper'
 

--- a/test/remote/remote_paypal_test.rb
+++ b/test/remote/remote_paypal_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RemotePaypalTest < Test::Unit::TestCase

--- a/test/remote/remote_payu_in_test.rb
+++ b/test/remote/remote_payu_in_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RemotePayuInTest < Test::Unit::TestCase

--- a/test/remote/remote_pxpay_test.rb
+++ b/test/remote/remote_pxpay_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'remote_test_helper'
 

--- a/test/remote/remote_quickpay_test.rb
+++ b/test/remote/remote_quickpay_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RemoteQuickPayTest < Test::Unit::TestCase

--- a/test/remote/remote_valitor_test.rb
+++ b/test/remote/remote_valitor_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'remote_test_helper'
 require 'nokogiri'

--- a/test/remote_test_helper.rb
+++ b/test/remote_test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'mechanize'
 require 'action_view/base'
 require 'launchy'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 
 require 'test/unit'
@@ -9,6 +11,7 @@ require 'yaml'
 require 'json'
 require 'nokogiri'
 
+require 'active_support'
 require 'active_support/core_ext/integer/time'
 require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/time/acts_like'
@@ -201,7 +204,7 @@ module ActionViewHelperTestHelper
       end
     end
     @controller = @controller.new
-    @output_buffer = ''
+    @output_buffer = +''
   end
 
   protected

--- a/test/unit/action_view_helper_test.rb
+++ b/test/unit/action_view_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ActionViewHelperTest < Test::Unit::TestCase

--- a/test/unit/fixtures_test.rb
+++ b/test/unit/fixtures_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class FixturesTest < Test::Unit::TestCase

--- a/test/unit/helper_test.rb
+++ b/test/unit/helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class HelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/a1agregator/a1agregator_helper_test.rb
+++ b/test/unit/integrations/a1agregator/a1agregator_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class A1agregatorHelperTest < Test::Unit::TestCase
   include OffsitePayments::Integrations
 

--- a/test/unit/integrations/a1agregator/a1agregator_module_test.rb
+++ b/test/unit/integrations/a1agregator/a1agregator_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class A1agregatorModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/a1agregator/a1agregator_notification_test.rb
+++ b/test/unit/integrations/a1agregator/a1agregator_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class A1agregatorNotificationTest < Test::Unit::TestCase
   include OffsitePayments::Integrations
 

--- a/test/unit/integrations/authorize_net_sim/authorize_net_sim_helper_test.rb
+++ b/test/unit/integrations/authorize_net_sim/authorize_net_sim_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AuthorizeNetSimHelperTest < Test::Unit::TestCase
   include OffsitePayments::Integrations
 

--- a/test/unit/integrations/authorize_net_sim/authorize_net_sim_module_test.rb
+++ b/test/unit/integrations/authorize_net_sim/authorize_net_sim_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class AuthorizeNetSimModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/authorize_net_sim/authorize_net_sim_notification_test.rb
+++ b/test/unit/integrations/authorize_net_sim/authorize_net_sim_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AuthorizeNetSimNotificationTest < Test::Unit::TestCase
   include OffsitePayments::Integrations
 

--- a/test/unit/integrations/bit_pay/bit_pay_helper_test.rb
+++ b/test/unit/integrations/bit_pay/bit_pay_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class BitPayHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/bit_pay/bit_pay_module_test.rb
+++ b/test/unit/integrations/bit_pay/bit_pay_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class BitPayModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/bit_pay/bit_pay_notification_test.rb
+++ b/test/unit/integrations/bit_pay/bit_pay_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class BitPayNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/bogus/bogus_helper_test.rb
+++ b/test/unit/integrations/bogus/bogus_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class BogusHelperTest < Test::Unit::TestCase
   include OffsitePayments::Integrations
 

--- a/test/unit/integrations/bogus/bogus_module_test.rb
+++ b/test/unit/integrations/bogus/bogus_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class BogusModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/checkout_finland/checkout_finland_helper_test.rb
+++ b/test/unit/integrations/checkout_finland/checkout_finland_helper_test.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class CheckoutFinlandHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/checkout_finland/checkout_finland_module_test.rb
+++ b/test/unit/integrations/checkout_finland/checkout_finland_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class CheckoutFinlandModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/checkout_finland/checkout_finland_notification_test.rb
+++ b/test/unit/integrations/checkout_finland/checkout_finland_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class CheckoutFinlandNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/chronopay/chronopay_helper_test.rb
+++ b/test/unit/integrations/chronopay/chronopay_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ChronopayHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/chronopay/chronopay_module_test.rb
+++ b/test/unit/integrations/chronopay/chronopay_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ChronopayModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/chronopay/chronopay_notification_test.rb
+++ b/test/unit/integrations/chronopay/chronopay_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ChronopayNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/chronopay/chronopay_return_test.rb
+++ b/test/unit/integrations/chronopay/chronopay_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ChronopayReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/citrus/citrus_helper_test.rb
+++ b/test/unit/integrations/citrus/citrus_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class CitrusHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/citrus/citrus_module_test.rb
+++ b/test/unit/integrations/citrus/citrus_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class CitrusModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/citrus/citrus_notification_test.rb
+++ b/test/unit/integrations/citrus/citrus_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class CitrusNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/citrus/citrus_return_test.rb
+++ b/test/unit/integrations/citrus/citrus_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class CitrusReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/coinbase/coinbase_helper_test.rb
+++ b/test/unit/integrations/coinbase/coinbase_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class CoinbaseHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/coinbase/coinbase_module_test.rb
+++ b/test/unit/integrations/coinbase/coinbase_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class CoinbaseModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/coinbase/coinbase_notification_test.rb
+++ b/test/unit/integrations/coinbase/coinbase_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class CoinbaseNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/coinbase/coinbase_return_test.rb
+++ b/test/unit/integrations/coinbase/coinbase_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class CoinbaseReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/direc_pay/direc_pay_helper_test.rb
+++ b/test/unit/integrations/direc_pay/direc_pay_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DirecPayHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/direc_pay/direc_pay_module_test.rb
+++ b/test/unit/integrations/direc_pay/direc_pay_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DirecPayModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/direc_pay/direc_pay_notification_test.rb
+++ b/test/unit/integrations/direc_pay/direc_pay_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DirecPayNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/direc_pay/direc_pay_return_test.rb
+++ b/test/unit/integrations/direc_pay/direc_pay_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DirecPayReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/directebanking/directebanking_helper_test.rb
+++ b/test/unit/integrations/directebanking/directebanking_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DirectebankingHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/directebanking/directebanking_notification_test.rb
+++ b/test/unit/integrations/directebanking/directebanking_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DirectebankingNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/directebanking/directebanking_return_test.rb
+++ b/test/unit/integrations/directebanking/directebanking_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DirectebankingReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/doku/doku_helper_test.rb
+++ b/test/unit/integrations/doku/doku_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DokuHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/doku/doku_module_test.rb
+++ b/test/unit/integrations/doku/doku_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DokuModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/doku/doku_notification_test.rb
+++ b/test/unit/integrations/doku/doku_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DokuNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/dotpay/dotpay_helper_test.rb
+++ b/test/unit/integrations/dotpay/dotpay_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DotpayHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/dotpay/dotpay_module_test.rb
+++ b/test/unit/integrations/dotpay/dotpay_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DotpayModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/dotpay/dotpay_notification_test.rb
+++ b/test/unit/integrations/dotpay/dotpay_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DotpayNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/dotpay/dotpay_return_test.rb
+++ b/test/unit/integrations/dotpay/dotpay_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DotpayReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/dwolla/dwolla_helper_test.rb
+++ b/test/unit/integrations/dwolla/dwolla_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'digest/sha1'
 

--- a/test/unit/integrations/dwolla/dwolla_module_test.rb
+++ b/test/unit/integrations/dwolla/dwolla_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DwollaModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/dwolla/dwolla_notification_test.rb
+++ b/test/unit/integrations/dwolla/dwolla_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DwollaNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/dwolla/dwolla_return_test.rb
+++ b/test/unit/integrations/dwolla/dwolla_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DwollaReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/e_payment_plans/e_payment_plans_helper_test.rb
+++ b/test/unit/integrations/e_payment_plans/e_payment_plans_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class EPaymentPlansHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/e_payment_plans/e_payment_plans_module_test.rb
+++ b/test/unit/integrations/e_payment_plans/e_payment_plans_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class EPaymentPlansModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/e_payment_plans/e_payment_plans_notification_test.rb
+++ b/test/unit/integrations/e_payment_plans/e_payment_plans_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class EPaymentPlansNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/easy_pay/easy_pay_helper_test.rb
+++ b/test/unit/integrations/easy_pay/easy_pay_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class EasyPayHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/easy_pay/easy_pay_module_test.rb
+++ b/test/unit/integrations/easy_pay/easy_pay_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class EasyPayModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/easy_pay/easy_pay_notification_test.rb
+++ b/test/unit/integrations/easy_pay/easy_pay_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class EasyPayNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/epay/epay_helper_test.rb
+++ b/test/unit/integrations/epay/epay_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class EpayHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/epay/epay_module_test.rb
+++ b/test/unit/integrations/epay/epay_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class EpayModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/epay/epay_notification_test.rb
+++ b/test/unit/integrations/epay/epay_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class EpayNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/first_data/first_data_helper_test.rb
+++ b/test/unit/integrations/first_data/first_data_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class FirstDataHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/first_data/first_data_module_test.rb
+++ b/test/unit/integrations/first_data/first_data_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class FirstDataModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/first_data/first_data_notification_test.rb
+++ b/test/unit/integrations/first_data/first_data_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class FirstDataNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/gestpay/gestpay_helper_test.rb
+++ b/test/unit/integrations/gestpay/gestpay_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class GestpayHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/gestpay/gestpay_module_test.rb
+++ b/test/unit/integrations/gestpay/gestpay_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class GestpayModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/gestpay/gestpay_notification_test.rb
+++ b/test/unit/integrations/gestpay/gestpay_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class GestpayNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/gestpay/gestpay_return_test.rb
+++ b/test/unit/integrations/gestpay/gestpay_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class GestpayReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/hi_trust/hi_trust_helper_test.rb
+++ b/test/unit/integrations/hi_trust/hi_trust_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class HiTrustHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/hi_trust/hi_trust_module_test.rb
+++ b/test/unit/integrations/hi_trust/hi_trust_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class HiTrustModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/hi_trust/hi_trust_notification_test.rb
+++ b/test/unit/integrations/hi_trust/hi_trust_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class HiTrustNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/hi_trust/hi_trust_return_test.rb
+++ b/test/unit/integrations/hi_trust/hi_trust_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class HiTrustReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/ipay88/ipay88_helper_test.rb
+++ b/test/unit/integrations/ipay88/ipay88_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Ipay88HelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/ipay88/ipay88_module_test.rb
+++ b/test/unit/integrations/ipay88/ipay88_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Ipay88ModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/ipay88/ipay88_notification_test.rb
+++ b/test/unit/integrations/ipay88/ipay88_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Ipay88NotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/ipay88/ipay88_return_test.rb
+++ b/test/unit/integrations/ipay88/ipay88_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Ipay88ReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/klarna/klarna_helper_test.rb
+++ b/test/unit/integrations/klarna/klarna_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class KlarnaHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/klarna/klarna_module_test.rb
+++ b/test/unit/integrations/klarna/klarna_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class KlarnaModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/klarna/klarna_notification_test.rb
+++ b/test/unit/integrations/klarna/klarna_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class KlarnaNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/liqpay/liqpay_helper_test.rb
+++ b/test/unit/integrations/liqpay/liqpay_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class LiqpayHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/liqpay/liqpay_module_test.rb
+++ b/test/unit/integrations/liqpay/liqpay_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class LiqpayModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/liqpay/liqpay_notification_test.rb
+++ b/test/unit/integrations/liqpay/liqpay_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class LiqpayNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/liqpay/liqpay_return_test.rb
+++ b/test/unit/integrations/liqpay/liqpay_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class LiqpayReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/maksuturva/maksuturva_helper_test.rb
+++ b/test/unit/integrations/maksuturva/maksuturva_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class MaksuturvaHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/maksuturva/maksuturva_module_test.rb
+++ b/test/unit/integrations/maksuturva/maksuturva_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MaksuturvaModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/maksuturva/maksuturva_notification_test.rb
+++ b/test/unit/integrations/maksuturva/maksuturva_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MaksuturvaNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/mollie/mollie_test.rb
+++ b/test/unit/integrations/mollie/mollie_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MollieTest < Test::Unit::TestCase

--- a/test/unit/integrations/mollie_ideal/mollie_ideal_helper_test.rb
+++ b/test/unit/integrations/mollie_ideal/mollie_ideal_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MollieIdealHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/mollie_ideal/mollie_ideal_module_test.rb
+++ b/test/unit/integrations/mollie_ideal/mollie_ideal_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MollieIdealModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/mollie_ideal/mollie_ideal_notification_test.rb
+++ b/test/unit/integrations/mollie_ideal/mollie_ideal_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MollieIdealNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/mollie_mistercash/mollie_mistercash_helper_test.rb
+++ b/test/unit/integrations/mollie_mistercash/mollie_mistercash_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MollieMistercashHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/mollie_mistercash/mollie_mistercash_module_test.rb
+++ b/test/unit/integrations/mollie_mistercash/mollie_mistercash_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MollieMistercashModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/mollie_mistercash/mollie_mistercash_notification_test.rb
+++ b/test/unit/integrations/mollie_mistercash/mollie_mistercash_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MollieMistercashNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/molpay/molpay_helper_test.rb
+++ b/test/unit/integrations/molpay/molpay_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MolpayHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/molpay/molpay_module_test.rb
+++ b/test/unit/integrations/molpay/molpay_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MolpayModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/molpay/molpay_notification_test.rb
+++ b/test/unit/integrations/molpay/molpay_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MolpayNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/molpay/molpay_return_test.rb
+++ b/test/unit/integrations/molpay/molpay_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MolpayReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/moneybookers/moneybookers_helper_test.rb
+++ b/test/unit/integrations/moneybookers/moneybookers_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MoneybookersHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/moneybookers/moneybookers_module_test.rb
+++ b/test/unit/integrations/moneybookers/moneybookers_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MoneybookersModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/moneybookers/moneybookers_notification_test.rb
+++ b/test/unit/integrations/moneybookers/moneybookers_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MoneybookersNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/nochex/nochex_helper_test.rb
+++ b/test/unit/integrations/nochex/nochex_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class NochexHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/nochex/nochex_module_test.rb
+++ b/test/unit/integrations/nochex/nochex_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class NochexModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/nochex/nochex_notification_test.rb
+++ b/test/unit/integrations/nochex/nochex_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class NochexNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/nochex/nochex_return_test.rb
+++ b/test/unit/integrations/nochex/nochex_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class NochexReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/pag_seguro/pag_seguro_helper_test.rb
+++ b/test/unit/integrations/pag_seguro/pag_seguro_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PagSeguroHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/pag_seguro/pag_seguro_module_test.rb
+++ b/test/unit/integrations/pag_seguro/pag_seguro_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PagSeguroModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/pag_seguro/pag_seguro_notification_test.rb
+++ b/test/unit/integrations/pag_seguro/pag_seguro_notification_test.rb
@@ -1,4 +1,5 @@
-# encoding: utf-8
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PagSeguroNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/paxum/paxum_helper_test.rb
+++ b/test/unit/integrations/paxum/paxum_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PaxumHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/paxum/paxum_module_test.rb
+++ b/test/unit/integrations/paxum/paxum_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PaxumModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/paxum/paxum_notification_test.rb
+++ b/test/unit/integrations/paxum/paxum_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PaxumNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/pay_fast/pay_fast_helper_test.rb
+++ b/test/unit/integrations/pay_fast/pay_fast_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PayFastHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/pay_fast/pay_fast_module_test.rb
+++ b/test/unit/integrations/pay_fast/pay_fast_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PayFastModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/pay_fast/pay_fast_notification_test.rb
+++ b/test/unit/integrations/pay_fast/pay_fast_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PayFastNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/paydollar/paydollar_helper_test.rb
+++ b/test/unit/integrations/paydollar/paydollar_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PaydollarHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/paydollar/paydollar_module_test.rb
+++ b/test/unit/integrations/paydollar/paydollar_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PaydollarModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/paydollar/paydollar_notification_test.rb
+++ b/test/unit/integrations/paydollar/paydollar_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PaydollarNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/paydollar/paydollar_return_test.rb
+++ b/test/unit/integrations/paydollar/paydollar_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PaydollarReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/payflow_link/payflow_link_helper_test.rb
+++ b/test/unit/integrations/payflow_link/payflow_link_helper_test.rb
@@ -1,4 +1,5 @@
-# encoding: utf-8
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PayflowLinkHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/payflow_link/payflow_link_notification_test.rb
+++ b/test/unit/integrations/payflow_link/payflow_link_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PayflowLinkNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/paypal/paypal_helper_test.rb
+++ b/test/unit/integrations/paypal/paypal_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PaypalHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/paypal/paypal_module_test.rb
+++ b/test/unit/integrations/paypal/paypal_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PaypalModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/paypal/paypal_notification_test.rb
+++ b/test/unit/integrations/paypal/paypal_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PaypalNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/paypal/paypal_return_test.rb
+++ b/test/unit/integrations/paypal/paypal_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PaypalReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/paypal_payments_advanced/paypal_payments_advanced_helper_test.rb
+++ b/test/unit/integrations/paypal_payments_advanced/paypal_payments_advanced_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PaypalPaymentsAdvancedHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/paysbuy/paysbuy_helper_test.rb
+++ b/test/unit/integrations/paysbuy/paysbuy_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PaysbuyHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/paysbuy/paysbuy_module_test.rb
+++ b/test/unit/integrations/paysbuy/paysbuy_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PaysbuyModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/paysbuy/paysbuy_notification_test.rb
+++ b/test/unit/integrations/paysbuy/paysbuy_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PaysbuyNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/paytm/paytm_helper_test.rb
+++ b/test/unit/integrations/paytm/paytm_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RemotePaytmTest < Test::Unit::TestCase

--- a/test/unit/integrations/paytm/paytm_module_test.rb
+++ b/test/unit/integrations/paytm/paytm_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PaytmModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/paytm/paytm_notification_test.rb
+++ b/test/unit/integrations/paytm/paytm_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PaytmNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/paytm/paytm_return_test.rb
+++ b/test/unit/integrations/paytm/paytm_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PaytmReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/payu_in/payu_in_helper_test.rb
+++ b/test/unit/integrations/payu_in/payu_in_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PayuInHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/payu_in/payu_in_module_test.rb
+++ b/test/unit/integrations/payu_in/payu_in_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PayuInModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/payu_in/payu_in_notification_test.rb
+++ b/test/unit/integrations/payu_in/payu_in_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PayuInNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/payu_in/payu_in_return_test.rb
+++ b/test/unit/integrations/payu_in/payu_in_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PayuInReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/payu_in_paisa/payu_in_paisa_helper_test.rb
+++ b/test/unit/integrations/payu_in_paisa/payu_in_paisa_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PayuInPaisaHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/payu_in_paisa/payu_in_paisa_module_test.rb
+++ b/test/unit/integrations/payu_in_paisa/payu_in_paisa_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PayuInPaisaModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/payu_in_paisa/payu_in_paisa_notification_test.rb
+++ b/test/unit/integrations/payu_in_paisa/payu_in_paisa_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PayuInPaisaNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/payu_in_paisa/payu_in_paisa_return_test.rb
+++ b/test/unit/integrations/payu_in_paisa/payu_in_paisa_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PayuInPaisaReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/platron/platron_helper_test.rb
+++ b/test/unit/integrations/platron/platron_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PlatronHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/platron/platron_module_test.rb
+++ b/test/unit/integrations/platron/platron_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PlatronModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/platron/platron_notification_test.rb
+++ b/test/unit/integrations/platron/platron_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PlatronNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/pxpay/pxpay_module_test.rb
+++ b/test/unit/integrations/pxpay/pxpay_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'nokogiri'
 

--- a/test/unit/integrations/pxpay/pxpay_notification_test.rb
+++ b/test/unit/integrations/pxpay/pxpay_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PxPayNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/quickpay/quickpay_helper_test.rb
+++ b/test/unit/integrations/quickpay/quickpay_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class QuickpayHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/quickpay/quickpay_module_test.rb
+++ b/test/unit/integrations/quickpay/quickpay_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class QuickpayModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/quickpay/quickpay_notification_test.rb
+++ b/test/unit/integrations/quickpay/quickpay_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class QuickpayNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/quickpay_v10/quickpay_v10_helper_test.rb
+++ b/test/unit/integrations/quickpay_v10/quickpay_v10_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class QuickpayV10HelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/quickpay_v10/quickpay_v10_module_test.rb
+++ b/test/unit/integrations/quickpay_v10/quickpay_v10_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class QuickpayV10ModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/quickpay_v10/quickpay_v10_notification_test.rb
+++ b/test/unit/integrations/quickpay_v10/quickpay_v10_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class QuickpayV10NotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/rbkmoney/rbkmoney_helper_test.rb
+++ b/test/unit/integrations/rbkmoney/rbkmoney_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RbkmoneyHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/rbkmoney/rbkmoney_module_test.rb
+++ b/test/unit/integrations/rbkmoney/rbkmoney_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RbkmoneyModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/rbkmoney/rbkmoney_notification_test.rb
+++ b/test/unit/integrations/rbkmoney/rbkmoney_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RbkmoneyNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/realex_offsite/realex_offsite_helper_test.rb
+++ b/test/unit/integrations/realex_offsite/realex_offsite_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RealexOffsiteHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/realex_offsite/realex_offsite_module_test.rb
+++ b/test/unit/integrations/realex_offsite/realex_offsite_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RealexOffsiteModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/realex_offsite/realex_offsite_notification_test.rb
+++ b/test/unit/integrations/realex_offsite/realex_offsite_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RealexOffsiteNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/robokassa/robokassa_helper_test.rb
+++ b/test/unit/integrations/robokassa/robokassa_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RobokassaHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/robokassa/robokassa_module_test.rb
+++ b/test/unit/integrations/robokassa/robokassa_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RobokassaModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/robokassa/robokassa_notification_test.rb
+++ b/test/unit/integrations/robokassa/robokassa_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RobokassaNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/sage_pay_form/sage_pay_form_helper_test.rb
+++ b/test/unit/integrations/sage_pay_form/sage_pay_form_helper_test.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 require 'test_helper'
 require 'active_support/core_ext/hash'

--- a/test/unit/integrations/sage_pay_form/sage_pay_form_module_test.rb
+++ b/test/unit/integrations/sage_pay_form/sage_pay_form_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class SagePayFormModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/sage_pay_form/sage_pay_form_notification_test.rb
+++ b/test/unit/integrations/sage_pay_form/sage_pay_form_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class SagePayFormNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/sage_pay_form/sage_pay_form_return_test.rb
+++ b/test/unit/integrations/sage_pay_form/sage_pay_form_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class SagePayFormReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/two_checkout/two_checkout_helper_test.rb
+++ b/test/unit/integrations/two_checkout/two_checkout_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TwoCheckoutHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/two_checkout/two_checkout_module_test.rb
+++ b/test/unit/integrations/two_checkout/two_checkout_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TwoCheckoutModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/two_checkout/two_checkout_notification_test.rb
+++ b/test/unit/integrations/two_checkout/two_checkout_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TwoCheckoutNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/two_checkout/two_checkout_return_test.rb
+++ b/test/unit/integrations/two_checkout/two_checkout_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TwoCheckoutReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/universal/universal_helper_test.rb
+++ b/test/unit/integrations/universal/universal_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class UniversalHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/universal/universal_module_test.rb
+++ b/test/unit/integrations/universal/universal_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class UniversalModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/universal/universal_notification_test.rb
+++ b/test/unit/integrations/universal/universal_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class UniversalNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/universal/universal_return_test.rb
+++ b/test/unit/integrations/universal/universal_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class UniversalReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/valitor/valitor_helper_test.rb
+++ b/test/unit/integrations/valitor/valitor_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ValitorHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/valitor/valitor_module_test.rb
+++ b/test/unit/integrations/valitor/valitor_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ValitorModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/valitor/valitor_notification_test.rb
+++ b/test/unit/integrations/valitor/valitor_notification_test.rb
@@ -1,4 +1,5 @@
-# encoding: utf-8
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ValitorNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/valitor/valitor_return_test.rb
+++ b/test/unit/integrations/valitor/valitor_return_test.rb
@@ -1,4 +1,5 @@
-# encoding: utf-8
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ValitorReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/verkkomaksut/verkkomaksut_helper_test.rb
+++ b/test/unit/integrations/verkkomaksut/verkkomaksut_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class VerkkomaksutHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/verkkomaksut/verkkomaksut_module_test.rb
+++ b/test/unit/integrations/verkkomaksut/verkkomaksut_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class VerkkomaksutModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/verkkomaksut/verkkomaksut_notification_test.rb
+++ b/test/unit/integrations/verkkomaksut/verkkomaksut_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class VerkkomaksutNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/web_pay/web_pay_helper_test.rb
+++ b/test/unit/integrations/web_pay/web_pay_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class WebPayHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/web_pay/web_pay_module_test.rb
+++ b/test/unit/integrations/web_pay/web_pay_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class WebPayModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/web_pay/web_pay_notification_test.rb
+++ b/test/unit/integrations/web_pay/web_pay_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class WebPayNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/webmoney/webmoney_helper_test.rb
+++ b/test/unit/integrations/webmoney/webmoney_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class WebmoneyHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/webmoney/webmoney_module_test.rb
+++ b/test/unit/integrations/webmoney/webmoney_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class WebmoneyModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/webmoney/webmoney_notification_test.rb
+++ b/test/unit/integrations/webmoney/webmoney_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class WebmoneyNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/wirecard_checkout_page/wirecard_checkout_page_helper_test.rb
+++ b/test/unit/integrations/wirecard_checkout_page/wirecard_checkout_page_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class WirecardCheckoutPageHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/wirecard_checkout_page/wirecard_checkout_page_module_test.rb
+++ b/test/unit/integrations/wirecard_checkout_page/wirecard_checkout_page_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class WirecardCheckoutPageModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/wirecard_checkout_page/wirecard_checkout_page_notification_test.rb
+++ b/test/unit/integrations/wirecard_checkout_page/wirecard_checkout_page_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class WirecardCheckoutPageNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations/wirecard_checkout_page/wirecard_checkout_page_return_test.rb
+++ b/test/unit/integrations/wirecard_checkout_page/wirecard_checkout_page_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class WirecardCheckoutPageReturnTest < Test::Unit::TestCase

--- a/test/unit/integrations/world_pay/world_pay_helper_test.rb
+++ b/test/unit/integrations/world_pay/world_pay_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class WorldPayHelperTest < Test::Unit::TestCase

--- a/test/unit/integrations/world_pay/world_pay_module_test.rb
+++ b/test/unit/integrations/world_pay/world_pay_module_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class WorldPayModuleTest < Test::Unit::TestCase

--- a/test/unit/integrations/world_pay/world_pay_notification_test.rb
+++ b/test/unit/integrations/world_pay/world_pay_notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class WorldPayNotificationTest < Test::Unit::TestCase

--- a/test/unit/integrations_test.rb
+++ b/test/unit/integrations_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class IntegrationsTest < Test::Unit::TestCase

--- a/test/unit/notification_test.rb
+++ b/test/unit/notification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class NotificationTest < Test::Unit::TestCase

--- a/test/unit/return_test.rb
+++ b/test/unit/return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ReturnTest < Test::Unit::TestCase


### PR DESCRIPTION
Integrations contain lots of literal strings, some of
which are common codes that are likely to be found elsewhere.

Enabling frozen string literals allow to deduplicate them.