### PR TITLE
Allow to parse CGI.escape content

### DIFF
--- a/lib/offsite_payments/notification.rb
+++ b/lib/offsite_payments/notification.rb
@@ -61,9 +61,9 @@ module OffsitePayments #:nodoc:
     # Take the posted data and move the relevant data into a hash
     def parse(post)
       @raw = post.to_s
-      for line in @raw.split('&')
+      for line in CGI.unescape(@raw).split('&')
         key, value = *line.scan( %r{^([A-Za-z0-9_.-]+)\=(.*)$} ).flatten
-        params[key] = CGI.unescape(value.to_s) if key.present?
+        params[key] = value.to_s if key.present?
       end
     end
   end


### PR DESCRIPTION
Hi,

[uri-escape-is-obsolete](https://docs.knapsackpro.com/2020/uri-escape-is-obsolete-percent-encoding-your-query-string),  I think most content will use CGI.escape to deal with.

But when use CGI.escape content come to here [Regexp (line 65)](https://github.com/activemerchant/offsite_payments/blame/master/lib/offsite_payments/notification.rb#L65)  will  parse nothing, because `CGI.escape('=')` become `%3D`, so the Regexp (line 65) can't recognize. If use `URI.escape('=')` will be fine because  `=` is  still `=` so the Regexp(line 65) can recognize.

etc: `CGI.escape('Status=SUCCESS') --> Status%3DSUCCESS` not working, `URI.escape('Status=SUCCESS')  --> Status=SUCCESS` work fine.

So I move original `CGI.unescape` little bit early to let [Regexp (line 65)](https://github.com/activemerchant/offsite_payments/blame/master/lib/offsite_payments/notification.rb#L65) can still recognize `URI.escape('=')` and plus `CGI.escape('=')`, because whether use which one to escape content both will come back to `=`. Hope This PR dose not change any logic and can work fine.

Thanks for your review and have a nice day :)

