### PR TITLE
Remove upper bound on active_utils version

### DIFF
--- a/offsite_payments.gemspec
+++ b/offsite_payments.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport', '>= 5.2.3')
   s.add_dependency('i18n', '>= 0.6.6')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
-  s.add_dependency('active_utils', '~> 3.3.0')
+  s.add_dependency('active_utils', '>= 3.3.0')
   s.add_dependency('nokogiri', ">= 1.8.5")
   s.add_dependency('actionpack', '>= 5.2.3')
   s.add_dependency('actionview','>= 5.1.6.2')


### PR DESCRIPTION
`active_utils` is currently pinned to `~> 3.3.0` in the Gemspec, which prevents Bundler from upgrading dependent applications to `active_utils-3.4.x` or newer.

I would like to relax this runtime dependency, bringing it inline with other dependencies in only having a lower bound.