### PR TITLE
Change shopify-money version to >= 2.0 in gemspec.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       builder (>= 2.1.2, < 4.0.0)
       i18n (>= 0.6.6)
       nokogiri (>= 1.8.5)
-      shopify-money (~> 2.0)
+      shopify-money (>= 2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -221,7 +221,7 @@ GEM
     rubyntlm (0.6.5)
       base64
     securerandom (0.3.1)
-    shopify-money (2.2.2)
+    shopify-money (3.0.0)
     stringio (3.1.1)
     test-unit (3.6.2)
       power_assert

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> [!CAUTION]  
+> [!CAUTION]
 > This gem is not actively maintained, and many of the integrations have not been updated in years. It is deprecated at Shopify, and should not be used.
 
 # Offsite Payments
@@ -39,19 +39,6 @@ Installation from RubyGems:
 Or, if you're using Bundler, just add the following to your Gemfile:
 
     gem 'offsite_payments'
-
-### Money gem dependency
-
-At the moment, `offsite_payments` gem depends on `Money` object, which was previously included by default. Since Shopify
-released their own `shopify-money` gem. Because `offsite_payments` does not impose which one of those gems should be
-included into your gem file, as long as one of them is included.
-
-
-- For [ruby money gem](https://github.com/RubyMoney/money) add `gem 'money'` to your `Gemfile`;
-- For [Shopify money gem](https://github.com/Shopify/money) add `gem 'shopify-money', require: 'money'` in your `Gemfile`.
-
-It's important to note that either of those Money gems would need to be added to your `Gemfile` before the `offsite_payments`
-one.
 
 [API documentation](http://www.rubydoc.info/github/activemerchant/offsite_payments/master).
 

--- a/offsite_payments.gemspec
+++ b/offsite_payments.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.metadata['allowed_push_host'] = "https://rubygems.org"
 
-  s.add_dependency('shopify-money', '~> 2.0')
+  s.add_dependency('shopify-money', '>= 2.0')
   s.add_dependency('activesupport', '>= 7.2.0')
   s.add_dependency('i18n', '>= 0.6.6')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')


### PR DESCRIPTION
Shopify wants to update offsite_payments to 3.0. However, there is a conflicting dependency on `shopify-money`. In core, we want 3.0 but offsite_payments specifies `~> 2.0`.

This dependency is only present in the gemspec, but not in Gemfile - it's unbounded there.

Additionally, since version 3.0 this gem [no longer supports non-Shopify Money gem](https://github.com/activemerchant/offsite_payments/pull/386/files#), so removed that section from the README.